### PR TITLE
Make skinned player dismissable, fill-width, and toggle-able

### DIFF
--- a/HarmonIQ/Skins/SkinManager.swift
+++ b/HarmonIQ/Skins/SkinManager.swift
@@ -15,9 +15,13 @@ final class SkinManager: ObservableObject {
 
     init() {
         reload()
-        // Restore last active skin (by display name).
+        // Restore last active skin (by display name). An empty string is the
+        // explicit "no skin" sentinel — we only auto-pick a default when no
+        // preference has ever been saved.
         let savedName = UserDefaults.standard.string(forKey: activeSkinKey)
-        if let name = savedName, let match = skins.first(where: { $0.displayName == name }) {
+        if savedName == "" {
+            activeSkin = nil
+        } else if let name = savedName, let match = skins.first(where: { $0.displayName == name }) {
             activeSkin = match
         } else {
             activeSkin = skins.first
@@ -61,6 +65,12 @@ final class SkinManager: ObservableObject {
     func selectSkin(_ skin: WinampSkin) {
         activeSkin = skin
         UserDefaults.standard.set(skin.displayName, forKey: activeSkinKey)
+    }
+
+    /// Disable skinning and fall back to the native SwiftUI now-playing view.
+    func clearSkin() {
+        activeSkin = nil
+        UserDefaults.standard.set("", forKey: activeSkinKey)
     }
 
     /// Copy a user-picked .wsz into the imported-skins directory and reload. Returns

--- a/HarmonIQ/Views/Skin/SkinnedMainView.swift
+++ b/HarmonIQ/Views/Skin/SkinnedMainView.swift
@@ -8,15 +8,34 @@ struct SkinnedMainView: View {
     @EnvironmentObject var skinManager: SkinManager
     @EnvironmentObject var player: AudioPlayerManager
     @StateObject private var visEngine = VisualizerEngine()
+    @Environment(\.dismiss) private var dismiss
 
     @State private var scrubbingPosition: Double? = nil
 
     var body: some View {
         GeometryReader { geo in
-            let pixel = max(1, floor(geo.size.width / SkinFormat.mainWindowSize.width))
+            // Fractional scale so the player fills the screen width even when the
+            // device width isn't an integer multiple of 275px. Sprites are still
+            // rendered with nearest-neighbor sampling (.interpolation(.none)) so
+            // the chunky look survives the non-integer scale.
+            let pixel = max(1, geo.size.width / SkinFormat.mainWindowSize.width)
             let canvasW = SkinFormat.mainWindowSize.width * pixel
             let canvasH = SkinFormat.mainWindowSize.height * pixel
             VStack(spacing: 0) {
+                HStack {
+                    Spacer()
+                    Button {
+                        dismiss()
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.title2)
+                            .foregroundStyle(.white.opacity(0.85), .black.opacity(0.6))
+                    }
+                    .accessibilityLabel("Close")
+                    .padding(.horizontal, 12)
+                    .padding(.top, 4)
+                    .padding(.bottom, 6)
+                }
                 ZStack(alignment: .topLeading) {
                     background(pixel: pixel, size: CGSize(width: canvasW, height: canvasH))
 

--- a/HarmonIQ/Views/SkinSettingsView.swift
+++ b/HarmonIQ/Views/SkinSettingsView.swift
@@ -9,6 +9,7 @@ struct SkinSettingsView: View {
     var body: some View {
         List {
             Section {
+                NoSkinRow()
                 ForEach(skinManager.skins) { skin in
                     SkinRow(skin: skin)
                 }
@@ -20,7 +21,7 @@ struct SkinSettingsView: View {
             } header: {
                 Text("Skins")
             } footer: {
-                Text("Tap a skin to apply it. Drop any classic Winamp 2.x skin (.wsz) in via the importer — same files that work in desktop Winamp.")
+                Text("Tap a skin to apply it, or pick \"None\" to use the native SwiftUI player. Drop any classic Winamp 2.x skin (.wsz) in via the importer — same files that work in desktop Winamp.")
             }
         }
         .navigationTitle("Skins")
@@ -50,6 +51,38 @@ struct SkinSettingsView: View {
             Button("OK", role: .cancel) {}
         } message: {
             Text(importError ?? "")
+        }
+    }
+}
+
+private struct NoSkinRow: View {
+    @EnvironmentObject var skinManager: SkinManager
+
+    var body: some View {
+        HStack(spacing: 12) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(Color.black)
+                Image(systemName: "circle.slash")
+                    .font(.title3)
+                    .foregroundStyle(.white.opacity(0.7))
+            }
+            .frame(width: 80, height: 34)
+            .overlay(RoundedRectangle(cornerRadius: 3).strokeBorder(Color.white.opacity(0.15)))
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("None (SwiftUI player)").font(.body)
+                Text("Use the native HarmonIQ player").font(.caption).foregroundStyle(.secondary)
+            }
+            Spacer()
+            if skinManager.activeSkin == nil {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.tint)
+            }
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            skinManager.clearSkin()
         }
     }
 }


### PR DESCRIPTION
## Summary
- **Close button**: adds an X at the top of `SkinnedMainView` so the now-playing sheet can be dismissed. The sheet was technically swipe-down dismissable, but the dense gesture surface (sliders + sprite buttons over most of the 275×116 canvas) left no drag handle.
- **Fill-width scaling**: switched from `floor(geo.width / 275)` to a fractional pixel size. Previously on iPhone-class widths (393–430pt) the floor pinned scale to 1px, leaving the player as a tiny strip in the corner. Sprites still render with `.interpolation(.none)`, so the chunky pixel aesthetic survives the non-integer scale.
- **Skin toggle**: adds a *None (SwiftUI player)* row to Settings → Skins so the user can disable skinning and fall back to `NowPlayingView`. New `SkinManager.clearSkin()` persists the choice via an empty-string sentinel in `UserDefaults` so it survives launches; auto-pick-first-skin only kicks in when no preference has ever been saved.

## Test plan
- [ ] Open a skinned now-playing sheet — confirm X button dismisses it.
- [ ] Confirm the 275×116 canvas now spans the full screen width on iPhone (Pro Max + non-Pro).
- [ ] Settings → Skins → tap *None* — confirm the next now-playing tap shows the SwiftUI `NowPlayingView` instead of the skinned UI; relaunch app, confirm choice persists.
- [ ] Settings → Skins → tap a skin — confirm skinned player returns and choice persists across relaunches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)