### PR TITLE
Add playlist + equalizer panels and surface playback errors

### DIFF
--- a/HarmonIQ.xcodeproj/project.pbxproj
+++ b/HarmonIQ.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		95C1D7862712B1AF3530D399 /* SkinFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982616423A6BC3BB174F0A2E /* SkinFormat.swift */; };
 		A10BD1CC54DC77E7DF551BA6 /* LibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CA5D219A5FF2CBA19A0E003 /* LibraryView.swift */; };
 		A9D09BD270A0DB94DD3F50C4 /* SkinnedMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A690CB3BB86B25F3B2E899 /* SkinnedMainView.swift */; };
+		C1D2E3F405061718292A3B4C /* SkinnedPlaylistView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E3F405061718292A3B4C5D /* SkinnedPlaylistView.swift */; };
+		C2E3F405061718292A3B4C5D /* SkinnedEqualizerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3F405061718292A3B4C5D6E /* SkinnedEqualizerView.swift */; };
 		ADFA445F84DD3EDB1A55C5DB /* WinampSkin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BBB248B178FE1FCF612ED97 /* WinampSkin.swift */; };
 		B5EE909DC0FD5E4684D545F9 /* Skins in Resources */ = {isa = PBXBuildFile; fileRef = 7D9E86967B7801F70269E055 /* Skins */; };
 		BFEC72EA12BDE9A75C6FFEB2 /* SkinnedVisualizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D68585262E7BD5EBB3CDF779 /* SkinnedVisualizer.swift */; };
@@ -93,6 +95,8 @@
 		ED17D95227132C92484D37D4 /* BitmapNumbers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitmapNumbers.swift; sourceTree = "<group>"; };
 		F01297D60CC5B6C050170B45 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		F1A690CB3BB86B25F3B2E899 /* SkinnedMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkinnedMainView.swift; sourceTree = "<group>"; };
+		D2E3F405061718292A3B4C5D /* SkinnedPlaylistView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkinnedPlaylistView.swift; sourceTree = "<group>"; };
+		E3F405061718292A3B4C5D6E /* SkinnedEqualizerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkinnedEqualizerView.swift; sourceTree = "<group>"; };
 		F53B7620084258E7F659C7D7 /* MetadataExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataExtractor.swift; sourceTree = "<group>"; };
 		F995634B51E300AA46B6DBF7 /* BitmapText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitmapText.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -117,6 +121,8 @@
 				F995634B51E300AA46B6DBF7 /* BitmapText.swift */,
 				BB566E7DBDC9F95DA534869C /* ScrollingBitmapText.swift */,
 				F1A690CB3BB86B25F3B2E899 /* SkinnedMainView.swift */,
+				D2E3F405061718292A3B4C5D /* SkinnedPlaylistView.swift */,
+				E3F405061718292A3B4C5D6E /* SkinnedEqualizerView.swift */,
 				D68585262E7BD5EBB3CDF779 /* SkinnedVisualizer.swift */,
 				645788E38767A20E50B440A4 /* SkinnedVolumeSlider.swift */,
 				C6203F24B0D3D962883456DA /* SpriteButton.swift */,
@@ -352,6 +358,8 @@
 				4ADB0C6545C514B0C7DD74BC /* SkinManager.swift in Sources */,
 				77D9EEF75A3909296BEF427B /* SkinSettingsView.swift in Sources */,
 				A9D09BD270A0DB94DD3F50C4 /* SkinnedMainView.swift in Sources */,
+				C1D2E3F405061718292A3B4C /* SkinnedPlaylistView.swift in Sources */,
+				C2E3F405061718292A3B4C5D /* SkinnedEqualizerView.swift in Sources */,
 				BFEC72EA12BDE9A75C6FFEB2 /* SkinnedVisualizer.swift in Sources */,
 				89D7DBC59590AF415A3B0191 /* SkinnedVolumeSlider.swift in Sources */,
 				16F8F24D50C9EB96562011DC /* SmartPlay.swift in Sources */,

--- a/HarmonIQ/Player/AudioPlayerManager.swift
+++ b/HarmonIQ/Player/AudioPlayerManager.swift
@@ -37,6 +37,9 @@ final class AudioPlayerManager: NSObject, ObservableObject {
     @Published var balance: Float = 0 {
         didSet { player?.pan = balance }
     }
+    /// User-visible reason the most recent play attempt failed, or nil if none.
+    /// Cleared when a track plays successfully or the queue empties.
+    @Published private(set) var playbackError: String?
 
     /// stableIDs of tracks that have started playing in this app session — fuels Discovery Mix.
     private(set) var sessionPlayedIDs: Set<String> = []
@@ -206,13 +209,32 @@ final class AudioPlayerManager: NSObject, ObservableObject {
             avPlayer.play()
             isPlaying = true
             currentTime = 0
+            playbackError = nil
             startDisplayLink()
             NowPlayingManager.shared.update(track: track, isPlaying: true, currentTime: 0, duration: self.duration)
         } catch {
             print("[HarmonIQ] Failed to play \(track.filename): \(error)")
             isPlaying = false
             stopDisplayLink()
+            playbackError = "Can't play \(track.filename): \(Self.friendlyMessage(for: error))"
         }
+    }
+
+    /// Translates the most common AVFoundation playback failures into something the
+    /// user can act on. Apple Music downloads (DRM-protected .m4p) and the
+    /// Files-app system folders that contain them are the usual culprits on
+    /// iPhone — surface that explicitly so the silence isn't mysterious.
+    private static func friendlyMessage(for error: Error) -> String {
+        let ns = error as NSError
+        if ns.domain == NSOSStatusErrorDomain {
+            // 'fmt?' / 'pty?' / -39 etc. all arrive here; whatever the OSStatus,
+            // the practical answer is "this file can't be decoded by AVAudioPlayer."
+            return "format not playable (DRM-protected, unsupported codec, or unreadable)"
+        }
+        if ns.domain == NSCocoaErrorDomain && ns.code == NSFileReadNoPermissionError {
+            return "no read permission for this file"
+        }
+        return ns.localizedDescription
     }
 
     private func advance(by delta: Int) {

--- a/HarmonIQ/Views/Skin/SkinnedEqualizerView.swift
+++ b/HarmonIQ/Views/Skin/SkinnedEqualizerView.swift
@@ -1,0 +1,137 @@
+import SwiftUI
+
+/// Winamp-style 10-band graphic equalizer + preamp + on/off + presets.
+///
+/// **Currently visual only** — moving sliders does not yet alter the audio.
+/// Hooking real EQ into AudioPlayerManager requires switching from
+/// `AVAudioPlayer` to `AVAudioEngine` + `AVAudioUnitEQ`, which is a separate,
+/// bigger change. The slider state lives here so the UI feels alive and the
+/// settings can be migrated over once the audio path moves to AVAudioEngine.
+struct SkinnedEqualizerView: View {
+    @StateObject private var state = EqualizerState.shared
+
+    private let bands: [String] = ["60", "170", "310", "600", "1K", "3K", "6K", "12K", "14K", "16K"]
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Title bar
+            HStack(spacing: 8) {
+                Text("EQUALIZER")
+                    .font(.system(size: 11, weight: .bold, design: .monospaced))
+                    .foregroundStyle(WinampTheme.lcdGlow)
+                Spacer()
+                Toggle(isOn: $state.isEnabled) {
+                    Text("ON")
+                        .font(.system(size: 10, weight: .bold, design: .monospaced))
+                        .foregroundStyle(state.isEnabled ? WinampTheme.lcdGlow : WinampTheme.lcdDim)
+                }
+                .toggleStyle(.button)
+                .tint(WinampTheme.accent)
+                Toggle(isOn: $state.autoMode) {
+                    Text("AUTO")
+                        .font(.system(size: 10, weight: .bold, design: .monospaced))
+                        .foregroundStyle(state.autoMode ? WinampTheme.lcdGlow : WinampTheme.lcdDim)
+                }
+                .toggleStyle(.button)
+                .tint(WinampTheme.accent)
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(LinearGradient(colors: [Color(white: 0.18), Color(white: 0.10)], startPoint: .top, endPoint: .bottom))
+
+            // Band sliders + preamp
+            HStack(alignment: .bottom, spacing: 6) {
+                bandSlider(title: "PRE", value: $state.preamp, isPreamp: true)
+                Rectangle().fill(Color(white: 0.2)).frame(width: 1)
+                ForEach(bands.indices, id: \.self) { i in
+                    bandSlider(title: bands[i], value: $state.bands[i], isPreamp: false)
+                }
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+
+            // Footer note
+            Text("Visual only — full audio EQ coming with AVAudioEngine")
+                .font(.system(size: 9, design: .monospaced))
+                .foregroundStyle(WinampTheme.lcdDim)
+                .frame(maxWidth: .infinity)
+                .padding(.bottom, 4)
+        }
+        .background(Color.black)
+        .overlay(Rectangle().stroke(Color(white: 0.25), lineWidth: 1))
+    }
+
+    private func bandSlider(title: String, value: Binding<Double>, isPreamp: Bool) -> some View {
+        VStack(spacing: 2) {
+            VerticalDbSlider(value: value, enabled: state.isEnabled)
+                .frame(width: 22, height: 90)
+            Text(title)
+                .font(.system(size: 9, weight: .bold, design: .monospaced))
+                .foregroundStyle(isPreamp ? WinampTheme.accent : (state.isEnabled ? WinampTheme.lcdGlow : WinampTheme.lcdDim))
+        }
+    }
+}
+
+/// -12 dB ... +12 dB vertical slider with a center notch line. Drawn in a
+/// hand-rolled style so it matches the Winamp aesthetic without requiring
+/// per-skin sprite atlases.
+private struct VerticalDbSlider: View {
+    @Binding var value: Double // -1...1, center 0 = 0 dB
+    var enabled: Bool
+
+    var body: some View {
+        GeometryReader { geo in
+            let w = geo.size.width
+            let h = geo.size.height
+            let centerY = h / 2
+            let knobH: CGFloat = 8
+            let travel = h - knobH
+            // value -1..1 → 0..travel (top is +12 dB i.e. value = +1)
+            let knobY = (1 - (value + 1) / 2) * travel
+
+            ZStack(alignment: .topLeading) {
+                // Track groove
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(Color(white: 0.08))
+                    .frame(width: 4, height: h)
+                    .offset(x: (w - 4) / 2, y: 0)
+
+                // Center 0 dB line
+                Rectangle()
+                    .fill(WinampTheme.lcdDim.opacity(0.4))
+                    .frame(width: w, height: 1)
+                    .offset(x: 0, y: centerY)
+
+                // Knob
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(enabled ? WinampTheme.lcdGlow : WinampTheme.lcdDim)
+                    .frame(width: w, height: knobH)
+                    .offset(x: 0, y: knobY)
+                    .shadow(color: enabled ? WinampTheme.lcdGlow.opacity(0.5) : .clear, radius: 2)
+            }
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { drag in
+                        let raw = (drag.location.y - knobH / 2) / max(1, travel)
+                        let clamped = max(0, min(1, raw))
+                        // top = +1, bottom = -1
+                        value = (1 - clamped) * 2 - 1
+                    }
+            )
+            .onTapGesture(count: 2) {
+                value = 0 // double-tap centers
+            }
+        }
+    }
+}
+
+@MainActor
+final class EqualizerState: ObservableObject {
+    static let shared = EqualizerState()
+
+    @Published var isEnabled: Bool = false
+    @Published var autoMode: Bool = false
+    @Published var preamp: Double = 0
+    @Published var bands: [Double] = Array(repeating: 0, count: 10)
+}

--- a/HarmonIQ/Views/Skin/SkinnedMainView.swift
+++ b/HarmonIQ/Views/Skin/SkinnedMainView.swift
@@ -11,6 +11,13 @@ struct SkinnedMainView: View {
     @Environment(\.dismiss) private var dismiss
 
     @State private var scrubbingPosition: Double? = nil
+    @State private var bottomPanel: BottomPanel = .playlist
+
+    private enum BottomPanel: String, CaseIterable, Identifiable {
+        case playlist = "Playlist"
+        case equalizer = "Equalizer"
+        var id: String { rawValue }
+    }
 
     var body: some View {
         GeometryReader { geo in
@@ -43,7 +50,43 @@ struct SkinnedMainView: View {
                         .frame(width: canvasW, height: canvasH, alignment: .topLeading)
                 }
                 .frame(width: canvasW, height: canvasH)
-                Spacer(minLength: 0)
+
+                if let err = player.playbackError {
+                    HStack(spacing: 6) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.orange)
+                        Text(err)
+                            .font(.system(size: 11, design: .monospaced))
+                            .foregroundStyle(.orange)
+                            .lineLimit(2)
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color.black.opacity(0.85))
+                }
+
+                Picker("", selection: $bottomPanel) {
+                    ForEach(BottomPanel.allCases) { p in
+                        Text(p.rawValue).tag(p)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .padding(.horizontal, 10)
+                .padding(.top, 8)
+                .padding(.bottom, 6)
+
+                Group {
+                    switch bottomPanel {
+                    case .playlist:
+                        SkinnedPlaylistView()
+                    case .equalizer:
+                        SkinnedEqualizerView()
+                    }
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding(.horizontal, 10)
+                .padding(.bottom, 10)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             .background(Color.black.ignoresSafeArea())

--- a/HarmonIQ/Views/Skin/SkinnedPlaylistView.swift
+++ b/HarmonIQ/Views/Skin/SkinnedPlaylistView.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+
+/// Winamp-style playlist editor: shows the current play queue as a tight,
+/// monospaced list. The currently playing row is highlighted; tapping a row
+/// jumps playback to that track.
+struct SkinnedPlaylistView: View {
+    @EnvironmentObject var player: AudioPlayerManager
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Title bar
+            HStack {
+                Text("PLAYLIST EDITOR")
+                    .font(.system(size: 11, weight: .bold, design: .monospaced))
+                    .foregroundStyle(WinampTheme.lcdGlow)
+                    .padding(.horizontal, 8)
+                Spacer()
+                Text("\(player.queue.count) tracks")
+                    .font(.system(size: 10, design: .monospaced))
+                    .foregroundStyle(WinampTheme.lcdDim)
+                    .padding(.horizontal, 8)
+            }
+            .padding(.vertical, 4)
+            .background(LinearGradient(colors: [Color(white: 0.18), Color(white: 0.10)], startPoint: .top, endPoint: .bottom))
+
+            if player.queue.isEmpty {
+                emptyState
+            } else {
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        LazyVStack(alignment: .leading, spacing: 0) {
+                            ForEach(Array(player.queue.enumerated()), id: \.offset) { idx, track in
+                                row(idx: idx, track: track)
+                                    .id(idx)
+                            }
+                        }
+                    }
+                    .onChange(of: player.currentIndex) { new in
+                        withAnimation { proxy.scrollTo(new, anchor: .center) }
+                    }
+                }
+            }
+        }
+        .background(Color.black)
+        .overlay(
+            Rectangle().stroke(Color(white: 0.25), lineWidth: 1)
+        )
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 6) {
+            Spacer()
+            Text("Queue is empty")
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundStyle(WinampTheme.lcdDim)
+            Text("Pick a track from the Library tab to start playback.")
+                .font(.system(size: 10, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 16)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func row(idx: Int, track: Track) -> some View {
+        let isCurrent = idx == player.currentIndex
+        return Button {
+            player.play(track: track, in: player.queue)
+        } label: {
+            HStack(spacing: 8) {
+                Text(String(format: "%2d.", idx + 1))
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(isCurrent ? WinampTheme.lcdGlow : WinampTheme.lcdDim)
+                    .frame(width: 28, alignment: .trailing)
+                Text("\(track.displayArtist) – \(track.displayTitle)")
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(isCurrent ? WinampTheme.lcdGlow : Color(white: 0.85))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                Spacer(minLength: 8)
+                Text(formatDuration(track.duration))
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(isCurrent ? WinampTheme.lcdGlow : WinampTheme.lcdDim)
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+            .background(isCurrent ? Color(white: 0.12) : Color.clear)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func formatDuration(_ seconds: TimeInterval) -> String {
+        guard seconds.isFinite, seconds > 0 else { return "--:--" }
+        let total = Int(seconds.rounded())
+        return String(format: "%d:%02d", total / 60, total % 60)
+    }
+}


### PR DESCRIPTION
Stacked on top of #2 (`skinned-player-fixes`). Merge that first, or rebase this onto `main` after #2 lands.

## Summary
- **Playlist editor panel** below the main skinned player: tight monospaced list of the current play queue with track #, "Artist – Title", and duration. Currently-playing row is highlighted in `lcdGlow`; tapping a row jumps playback to that track; auto-scrolls to center the current row as playback advances.
- **Equalizer panel** (10-band + preamp + on/off + auto): hand-rolled vertical dB sliders that match the Winamp aesthetic without needing per-skin sprite atlases. **Currently visual-only** — state lives in `EqualizerState` for future wiring. Moving sliders does not alter audio because that needs `AVAudioPlayer` → `AVAudioEngine + AVAudioUnitEQ`. The footer caption says so explicitly.
- **Segmented control** above the panels switches between *Playlist* / *Equalizer*.
- **Playback error surfacing**: `AudioPlayerManager.playbackError` (`@Published`) is set in `playCurrent`'s catch block (and cleared on next successful play). The skinned player shows it in an orange banner under the main canvas. `friendlyMessage()` translates `NSOSStatusErrorDomain` failures into "format not playable (DRM-protected, unsupported codec, or unreadable)" so the iPhone *Music* folder + Apple Music DRM case is no longer mysterious silence.

## Why no real EQ yet
`AVAudioPlayer` doesn't expose a parametric EQ. Wiring real EQ means moving the entire playback path to `AVAudioEngine + AVAudioPlayerNode + AVAudioUnitEQ`, which also forces redoing metering (currently `averagePower`/`peakPower` on `AVAudioPlayer`), scrubbing, time tracking, route-change handling, and the delegate. That's a much bigger PR — kept out of this one. `EqualizerState.shared` already holds the band/preamp values so the migration is just rewiring the audio graph.

## Test plan
- [ ] Skinned now-playing sheet shows main player + segmented control + Playlist (default) / Equalizer panels stacked vertically.
- [ ] Switch to *Playlist* — current track is highlighted in green, list auto-scrolls; tap another row to jump.
- [ ] Switch to *Equalizer* — drag sliders, double-tap a slider to recenter at 0 dB, toggle ON/AUTO buttons.
- [ ] Confirm the orange "Visual only — full audio EQ coming with AVAudioEngine" caption is visible.
- [ ] Try playing a DRM-protected `.m4p` (or a folder with one) — confirm orange banner appears with the friendly message and *no* console-only silence.
- [ ] Play a normal MP3 — confirm banner disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)