### PR TITLE
Auto-present now-playing sheet on track tap; reactivate audio session

### DIFF
--- a/HarmonIQ/Player/AudioPlayerManager.swift
+++ b/HarmonIQ/Player/AudioPlayerManager.swift
@@ -41,6 +41,11 @@ final class AudioPlayerManager: NSObject, ObservableObject {
     /// Cleared when a track plays successfully or the queue empties.
     @Published private(set) var playbackError: String?
 
+    /// Counter that increments every time `play(track:in:)` is invoked by the
+    /// user. ContentView observes this to auto-present the now-playing sheet
+    /// so a track tap immediately opens the Winamp interface.
+    @Published private(set) var presentNowPlayingTick: Int = 0
+
     /// stableIDs of tracks that have started playing in this app session — fuels Discovery Mix.
     private(set) var sessionPlayedIDs: Set<String> = []
 
@@ -63,6 +68,7 @@ final class AudioPlayerManager: NSObject, ObservableObject {
         activeSmartMode = nil
         loadQueue(normalized, startIndex: startIdx)
         playCurrent()
+        presentNowPlayingTick &+= 1
     }
 
     func playAll(_ tracks: [Track], startAt index: Int = 0) {
@@ -70,6 +76,7 @@ final class AudioPlayerManager: NSObject, ObservableObject {
         activeSmartMode = nil
         loadQueue(tracks, startIndex: max(0, min(index, tracks.count - 1)))
         playCurrent()
+        presentNowPlayingTick &+= 1
     }
 
     /// Build a queue with a SmartPlayMode and start playback. Disables manual shuffle so
@@ -81,6 +88,7 @@ final class AudioPlayerManager: NSObject, ObservableObject {
         isShuffleEnabled = false
         loadQueue(queue, startIndex: 0)
         playCurrent()
+        presentNowPlayingTick &+= 1
     }
 
     func togglePlayPause() {
@@ -182,6 +190,15 @@ final class AudioPlayerManager: NSObject, ObservableObject {
         do {
             stopDisplayLink()
             releaseAccessRoot()
+
+            // Re-activate the audio session in case an interruption (phone
+            // call, Siri, another app) deactivated it. Without this, the file
+            // loads and "plays" but produces no audible output.
+            let session = AVAudioSession.sharedInstance()
+            if session.category != .playback {
+                try? session.setCategory(.playback, mode: .default, options: [])
+            }
+            try? session.setActive(true, options: [])
 
             // Resolve security-scoped access for the root drive that owns this track.
             guard let root = LibraryStore.shared.roots.first(where: { $0.id == track.rootBookmarkID }) else {

--- a/HarmonIQ/Views/ContentView.swift
+++ b/HarmonIQ/Views/ContentView.swift
@@ -38,6 +38,14 @@ struct ContentView: View {
                 NowPlayingView()
             }
         }
+        // Auto-present the player when the user taps a track anywhere in the
+        // app. AudioPlayerManager increments presentNowPlayingTick on every
+        // user-initiated play() / playAll() / playSmart() call (but NOT on
+        // Next/Previous from inside the player), so the sheet pops up on
+        // first selection without re-triggering as playback advances.
+        .onReceive(player.$presentNowPlayingTick.dropFirst()) { _ in
+            showNowPlaying = true
+        }
     }
 }
 


### PR DESCRIPTION
Stacked on top of #4 → #2. Merge in order: #2, #4, then this.

## Summary
Two fixes for *"I tapped a track and nothing happened"*:

- **Auto-present the player on track tap.** `AudioPlayerManager.play` / `playAll` / `playSmart` increment a new `presentNowPlayingTick` counter. `ContentView` observes the counter (`.onReceive(player.\$presentNowPlayingTick.dropFirst())`) and sets `showNowPlaying = true`, so picking a track from any list immediately opens the Winamp interface. The counter only ticks on user-initiated play calls — Next/Previous from inside the player don't retrigger the sheet, so dismissing and browsing still works.
- **Reactivate `AVAudioSession` before playback.** Interruptions (phone call, Siri, another app, route change) can leave the session deactivated; the file then loads and "plays" with no audible output. `playCurrent` now restores the `.playback` category if it drifted and calls `setActive(true)` every time, so a tap reliably produces sound.

## Why both
The user reported *no sound* and *clicking a track should immediately go into the Winamp interface to play* in the same message. The audio-session reactivation is the most likely cause of silence in the playback path (the file loads cleanly so no error banner triggers), and the auto-present makes the player always visible after a tap — which also surfaces the orange "Can't play" banner from #4 for any future failures.

## Test plan
- [ ] Tap any track from Library → Now-Playing sheet opens immediately (skinned or SwiftUI).
- [ ] Tap a track in the in-sheet Playlist editor → no extra sheet pops, current sheet stays.
- [ ] Hit Next/Previous in the sheet → no re-presentation, sheet stays open.
- [ ] Dismiss sheet → tap another track → sheet reopens.
- [ ] On a real iPhone after a phone call or Siri, tap a track → audible output (audio session reactivated).
- [ ] Standard play of an MP3 → audible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)