### PR TITLE
Use ZIPFoundation's throwing Archive init in SkinLoader

### DIFF
--- a/HarmonIQ/Skins/SkinLoader.swift
+++ b/HarmonIQ/Skins/SkinLoader.swift
@@ -14,7 +14,10 @@ enum SkinLoader {
     /// Load the skin at the given URL. Caller is responsible for security-scoped access
     /// if the URL points outside the app sandbox.
     static func load(from url: URL, isBundled: Bool) throws -> WinampSkin {
-        guard let archive = try? Archive(url: url, accessMode: .read) else {
+        let archive: Archive
+        do {
+            archive = try Archive(url: url, accessMode: .read)
+        } catch {
             throw SkinLoaderError.openFailed
         }
 

--- a/HarmonIQ/Views/Visualizers.swift
+++ b/HarmonIQ/Views/Visualizers.swift
@@ -153,12 +153,11 @@ final class VisualizerEngine: ObservableObject {
 // MARK: - Drawing
 
 private func drawScanlines(context: GraphicsContext, size: CGSize) {
-    var ctx = context
     let lineH: CGFloat = 2
     var y: CGFloat = 0
     let color = Color.white.opacity(0.04)
     while y < size.height {
-        ctx.fill(Path(CGRect(x: 0, y: y, width: size.width, height: 1)), with: .color(color))
+        context.fill(Path(CGRect(x: 0, y: y, width: size.width, height: 1)), with: .color(color))
         y += lineH
     }
 }


### PR DESCRIPTION
## Summary
Silences the build warning *"`init(url:accessMode:preferredEncoding:)` is deprecated: Please use the throwing initializer."*

The failable `Archive(url:accessMode:preferredEncoding:)` initializer is deprecated in current ZIPFoundation; calling it via `try?` silently picks the deprecated overload. Switch `SkinLoader.load` to the throwing initializer inside a `do`/`catch`, mapping any failure to `SkinLoaderError.openFailed` so the public API is unchanged.

## Test plan
- [ ] Build → no deprecation warning on `Archive(url:...)`.
- [ ] Apply a bundled `.wsz` skin → loads identically.
- [ ] Apply a corrupted `.wsz` (or a non-zip file renamed to `.wsz`) → throws `SkinLoaderError.openFailed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)