### PR TITLE
Stack equalizer above playlist instead of segmented tabs

### DIFF
--- a/HarmonIQ/Views/Skin/SkinnedMainView.swift
+++ b/HarmonIQ/Views/Skin/SkinnedMainView.swift
@@ -11,13 +11,6 @@ struct SkinnedMainView: View {
     @Environment(\.dismiss) private var dismiss
 
     @State private var scrubbingPosition: Double? = nil
-    @State private var bottomPanel: BottomPanel = .playlist
-
-    private enum BottomPanel: String, CaseIterable, Identifiable {
-        case playlist = "Playlist"
-        case equalizer = "Equalizer"
-        var id: String { rawValue }
-    }
 
     var body: some View {
         GeometryReader { geo in
@@ -66,27 +59,21 @@ struct SkinnedMainView: View {
                     .background(Color.black.opacity(0.85))
                 }
 
-                Picker("", selection: $bottomPanel) {
-                    ForEach(BottomPanel.allCases) { p in
-                        Text(p.rawValue).tag(p)
-                    }
-                }
-                .pickerStyle(.segmented)
-                .padding(.horizontal, 10)
-                .padding(.top, 8)
-                .padding(.bottom, 6)
+                // Stack the equalizer above the playlist to match Winamp's
+                // top-to-bottom window order. The EQ takes a fixed height
+                // (sliders + labels need consistent room); the playlist gets
+                // the remaining flexible space and scrolls internally when
+                // the queue is long.
+                SkinnedEqualizerView()
+                    .frame(height: 200)
+                    .padding(.horizontal, 10)
+                    .padding(.top, 8)
 
-                Group {
-                    switch bottomPanel {
-                    case .playlist:
-                        SkinnedPlaylistView()
-                    case .equalizer:
-                        SkinnedEqualizerView()
-                    }
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .padding(.horizontal, 10)
-                .padding(.bottom, 10)
+                SkinnedPlaylistView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .padding(.horizontal, 10)
+                    .padding(.top, 8)
+                    .padding(.bottom, 10)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             .background(Color.black.ignoresSafeArea())


### PR DESCRIPTION
**Stacked on PR #7** (`recover-pr4-pr5`). Per the saved-feedback rule about stacked PRs, retarget this to `main` *before* merging #7 — or just merge #7 first, and this PR will auto-rebase to `main`.

## Summary
The previous segmented Picker (Playlist / Equalizer tabs) was a poor fit for iPhone's vertical real estate: ~700pt sits empty under the main player canvas, easily enough for both panels at once.

This PR drops the Picker and the `BottomPanel` state and stacks:

```
Main player canvas
Equalizer (fixed 200pt — fits 90pt sliders + title + footer caption)
Playlist (flexible, fills remaining space, scrolls internally)
```

Order matches Winamp 2.x's classic top-to-bottom window arrangement (Main → EQ → Playlist). The user can see what's playing, the EQ state, and the queue at the same time.

## Test plan
- [ ] Open the now-playing sheet on iPhone — confirm Main + EQ + Playlist all visible without tab flipping.
- [ ] Confirm EQ takes ~200pt and the playlist scrolls internally with a long queue.
- [ ] Tap a different track in the playlist — confirm playback jumps and the highlight updates.
- [ ] On a smaller iPhone (e.g., SE) the playlist may shrink; confirm at least 2-3 rows are visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)