### PR TITLE
Add inline skin picker menu to the skinned player

### DIFF
--- a/HarmonIQ/Views/Skin/SkinnedMainView.swift
+++ b/HarmonIQ/Views/Skin/SkinnedMainView.swift
@@ -23,7 +23,31 @@ struct SkinnedMainView: View {
             let canvasH = SkinFormat.mainWindowSize.height * pixel
             VStack(spacing: 0) {
                 HStack {
+                    Menu {
+                        Button {
+                            skinManager.clearSkin()
+                        } label: {
+                            Label("None (SwiftUI player)",
+                                  systemImage: skinManager.activeSkin == nil ? "checkmark" : "circle")
+                        }
+                        Divider()
+                        ForEach(skinManager.skins) { skin in
+                            Button {
+                                skinManager.selectSkin(skin)
+                            } label: {
+                                Label(skin.displayName,
+                                      systemImage: skinManager.activeSkin?.id == skin.id ? "checkmark" : "circle")
+                            }
+                        }
+                    } label: {
+                        Image(systemName: "paintpalette.fill")
+                            .font(.title2)
+                            .foregroundStyle(.white.opacity(0.85), .black.opacity(0.6))
+                    }
+                    .accessibilityLabel("Switch skin")
+
                     Spacer()
+
                     Button {
                         dismiss()
                     } label: {
@@ -32,10 +56,10 @@ struct SkinnedMainView: View {
                             .foregroundStyle(.white.opacity(0.85), .black.opacity(0.6))
                     }
                     .accessibilityLabel("Close")
-                    .padding(.horizontal, 12)
-                    .padding(.top, 4)
-                    .padding(.bottom, 6)
                 }
+                .padding(.horizontal, 12)
+                .padding(.top, 4)
+                .padding(.bottom, 6)
                 ZStack(alignment: .topLeading) {
                     background(pixel: pixel, size: CGSize(width: canvasW, height: canvasH))
 


### PR DESCRIPTION
## Summary
The skin switcher already lives at *Settings → Appearance → Skins* on `main`, but reaching it from the now-playing sheet requires dismissing, switching tabs, and tapping through two levels of navigation. Add a paintpalette button next to the existing close button that opens a Menu listing every installed skin plus a *None (SwiftUI player)* option. Active skin shows a checkmark; tapping a row applies it immediately via the existing `SkinManager.selectSkin` / `clearSkin`.

Mirrors Winamp's right-click → Skins picker on the desktop, so the gesture is familiar to anyone coming from classic Winamp.

## Heads up — overlapping diff with PR #7 / #8
This branch is off `main`, but it edits the same close-button row in `SkinnedMainView` that PR #7 / #8 also touches (PR #7 has the playback-error banner, PR #8 stacks EQ above playlist). Whichever lands second will need a one-line conflict resolution in the close-button HStack — the menu addition is straightforward to keep alongside the panel changes.

## Test plan
- [ ] Open now-playing sheet → paintpalette icon visible at top-left, X at top-right.
- [ ] Tap paintpalette → menu shows *None (SwiftUI player)* at top, then bundled skins, with active one checked.
- [ ] Pick a different skin → player updates immediately to the new sprites without dismissing the sheet.
- [ ] Pick *None* → sheet swaps to the SwiftUI `NowPlayingView`.
- [ ] Choice persists across app relaunches (existing `SkinManager.selectSkin` / `clearSkin` already saves it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)