### PR TITLE
Recover PR #8: stack equalizer above playlist

### DIFF
--- a/HarmonIQ/Views/Skin/SkinnedMainView.swift
+++ b/HarmonIQ/Views/Skin/SkinnedMainView.swift
@@ -11,13 +11,6 @@ struct SkinnedMainView: View {
     @Environment(\.dismiss) private var dismiss
 
     @State private var scrubbingPosition: Double? = nil
-    @State private var bottomPanel: BottomPanel = .playlist
-
-    private enum BottomPanel: String, CaseIterable, Identifiable {
-        case playlist = "Playlist"
-        case equalizer = "Equalizer"
-        var id: String { rawValue }
-    }
 
     var body: some View {
         GeometryReader { geo in
@@ -90,27 +83,21 @@ struct SkinnedMainView: View {
                     .background(Color.black.opacity(0.85))
                 }
 
-                Picker("", selection: $bottomPanel) {
-                    ForEach(BottomPanel.allCases) { p in
-                        Text(p.rawValue).tag(p)
-                    }
-                }
-                .pickerStyle(.segmented)
-                .padding(.horizontal, 10)
-                .padding(.top, 8)
-                .padding(.bottom, 6)
+                // Stack the equalizer above the playlist to match Winamp's
+                // top-to-bottom window order. The EQ takes a fixed height
+                // (sliders + labels need consistent room); the playlist gets
+                // the remaining flexible space and scrolls internally when
+                // the queue is long.
+                SkinnedEqualizerView()
+                    .frame(height: 200)
+                    .padding(.horizontal, 10)
+                    .padding(.top, 8)
 
-                Group {
-                    switch bottomPanel {
-                    case .playlist:
-                        SkinnedPlaylistView()
-                    case .equalizer:
-                        SkinnedEqualizerView()
-                    }
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .padding(.horizontal, 10)
-                .padding(.bottom, 10)
+                SkinnedPlaylistView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .padding(.horizontal, 10)
+                    .padding(.top, 8)
+                    .padding(.bottom, 10)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             .background(Color.black.ignoresSafeArea())


### PR DESCRIPTION
## Why
PR #8 hit the same stacked-PR orphan trap as PR #4/#5: its base was `recover-pr4-pr5` (also a recovery branch). When that base merged and was deleted, GitHub completed the "merge" of #8 against the deleted base — marking it MERGED but leaving the commit unreachable from `main`. Verified via `gh pr view 8 --json baseRefName` (= `recover-pr4-pr5`) and `grep BottomPanel HarmonIQ/Views/Skin/SkinnedMainView.swift` on main (still 4 references — segmented Picker is still there).

This branch cherry-picks the original commit (`de841d3`) onto `main` so the stacked layout actually lands.

## What changes
Drops the segmented Picker + `BottomPanel` enum from `SkinnedMainView` and stacks the panels directly:

```
Main player canvas
Equalizer (fixed 200pt)
Playlist (flexible, scrolls internally)
```

## Test plan
- [ ] Open now-playing sheet on iPhone — see player + EQ + Playlist all at once, no tabs.
- [ ] Long playlist scrolls inside its panel without pushing EQ off-screen.
- [ ] Tap a different track in the playlist — confirm playback jumps and the highlight updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)