### PR TITLE
Fix bogus read-only flag on every root + add delete to Folders

### DIFF
--- a/HarmonIQ/Views/FoldersView.swift
+++ b/HarmonIQ/Views/FoldersView.swift
@@ -28,6 +28,18 @@ struct FoldersView: View {
                                 }
                             }
                         }
+                        .swipeActions {
+                            Button(role: .destructive) {
+                                library.removeRoot(root)
+                            } label: {
+                                Label("Remove", systemImage: "trash")
+                            }
+                        }
+                    }
+                    .onDelete { offsets in
+                        for idx in offsets {
+                            library.removeRoot(library.roots[idx])
+                        }
                     }
                 }
             }

--- a/HarmonIQ/Views/SettingsView.swift
+++ b/HarmonIQ/Views/SettingsView.swift
@@ -69,6 +69,15 @@ struct SettingsView: View {
     }
 
     private func addRoot(from url: URL) {
+        // The URL handed to us by UIDocumentPickerViewController is only
+        // transiently accessible. To capture *write* access in the bookmark
+        // we must explicitly start security scope before serializing it —
+        // otherwise the bookmark resolves later as read-only and every
+        // folder ends up flagged isReadOnly even when it's a writable
+        // location on the device.
+        let started = url.startAccessingSecurityScopedResource()
+        defer { if started { url.stopAccessingSecurityScopedResource() } }
+
         do {
             let bookmark = try url.bookmarkData(options: [], includingResourceValuesForKeys: nil, relativeTo: nil)
             let root = LibraryRoot(displayName: url.lastPathComponent, bookmark: bookmark)


### PR DESCRIPTION
Two real-iPhone bugs:

## 1. Every folder ended up flagged read-only
`SettingsView.addRoot` didn't open security scope on the picker URL before serializing the bookmark. The URL handed back by `UIDocumentPickerViewController` is only transiently in-scope; without an explicit `startAccessingSecurityScopedResource()` call, the resulting bookmark resolves later as read-only and `DriveLibraryStore.ensureFolders` fails with `NSFileWriteNoPermissionError` on every write — even for perfectly writable folders on *On My iPhone*.

User report: *"all folders I selected are 'read-only', even though it was a local folder on my iphone."*

Fix: wrap `bookmarkData(...)` between `start/stopAccessingSecurityScopedResource()` so the bookmark carries the writable scope. The read-only fallback (added in #3) only triggers for genuinely read-only locations now (iOS system *Music*, certain iCloud paths).

## 2. No delete in the Folders view
`FoldersView` listed roots at the top level but had no way to remove one — the user had to switch to the Settings tab. Add `.swipeActions` + `.onDelete` matching `SettingsView`'s existing handlers.

## Test plan
- [ ] Pick a fresh folder on **On My iPhone → HarmonIQ** → confirm indexing completes and the row does **not** show the orange *Read-only* pill.
- [ ] Re-pick the iOS system *Music* folder → confirm the *Read-only* pill still shows (genuine read-only path).
- [ ] In Library → Folders, swipe-left on a root → tap *Remove* → confirm the root + tracks disappear.
- [ ] Same path via the iOS multi-edit gesture (`onDelete`) → confirm same result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)