### PR TITLE
Drop mini player; track skin colors in EQ/Playlist; skin picker on SwiftUI player

### DIFF
--- a/HarmonIQ/Views/ContentView.swift
+++ b/HarmonIQ/Views/ContentView.swift
@@ -24,12 +24,6 @@ struct ContentView: View {
                     .tabItem { Label("Settings", systemImage: "gearshape") }
             }
             .scrollContentBackground(.hidden)
-            .safeAreaInset(edge: .bottom, spacing: 0) {
-                if player.currentTrack != nil {
-                    MiniPlayerView()
-                        .onTapGesture { showNowPlaying = true }
-                }
-            }
         }
         .sheet(isPresented: $showNowPlaying) {
             if skinManager.activeSkin != nil {

--- a/HarmonIQ/Views/NowPlayingView.swift
+++ b/HarmonIQ/Views/NowPlayingView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct NowPlayingView: View {
     @EnvironmentObject var player: AudioPlayerManager
+    @EnvironmentObject var skinManager: SkinManager
     @Environment(\.dismiss) private var dismiss
     @State private var seekingValue: Double?
 
@@ -10,10 +11,48 @@ struct NowPlayingView: View {
             WinampTheme.appBackground.ignoresSafeArea()
 
             VStack(spacing: 18) {
-                Capsule()
-                    .fill(WinampTheme.bevelLight.opacity(0.25))
-                    .frame(width: 40, height: 5)
-                    .padding(.top, 8)
+                // Skin picker + grab handle. Without the skin picker here,
+                // selecting "None (SwiftUI player)" left no way to switch
+                // back to a skinned player from the now-playing screen.
+                HStack {
+                    Menu {
+                        Button {
+                            skinManager.clearSkin()
+                        } label: {
+                            Label("None (SwiftUI player)",
+                                  systemImage: skinManager.activeSkin == nil ? "checkmark" : "circle")
+                        }
+                        Divider()
+                        ForEach(skinManager.skins) { skin in
+                            Button {
+                                skinManager.selectSkin(skin)
+                            } label: {
+                                Label(skin.displayName,
+                                      systemImage: skinManager.activeSkin?.id == skin.id ? "checkmark" : "circle")
+                            }
+                        }
+                    } label: {
+                        Image(systemName: "paintpalette.fill")
+                            .font(.title3)
+                            .foregroundStyle(WinampTheme.lcdGlow.opacity(0.85))
+                    }
+                    .accessibilityLabel("Switch skin")
+
+                    Spacer()
+
+                    Capsule()
+                        .fill(WinampTheme.bevelLight.opacity(0.25))
+                        .frame(width: 40, height: 5)
+
+                    Spacer()
+
+                    // Symmetric spacer so the capsule stays centered.
+                    Image(systemName: "paintpalette.fill")
+                        .font(.title3)
+                        .opacity(0)
+                }
+                .padding(.horizontal, 16)
+                .padding(.top, 8)
 
                 // LCD readout strip — title scroll + bitrate-style stats
                 VStack(spacing: 4) {

--- a/HarmonIQ/Views/Skin/SkinnedEqualizerView.swift
+++ b/HarmonIQ/Views/Skin/SkinnedEqualizerView.swift
@@ -9,31 +9,36 @@ import SwiftUI
 /// settings can be migrated over once the audio path moves to AVAudioEngine.
 struct SkinnedEqualizerView: View {
     @StateObject private var state = EqualizerState.shared
+    @EnvironmentObject var skinManager: SkinManager
 
     private let bands: [String] = ["60", "170", "310", "600", "1K", "3K", "6K", "12K", "14K", "16K"]
 
     var body: some View {
+        let palette = SkinPalette(skin: skinManager.activeSkin)
+        let activeColor = palette.current
+        let dimColor = palette.normal.opacity(0.6)
+
         VStack(spacing: 0) {
             // Title bar
             HStack(spacing: 8) {
                 Text("EQUALIZER")
                     .font(.system(size: 11, weight: .bold, design: .monospaced))
-                    .foregroundStyle(WinampTheme.lcdGlow)
+                    .foregroundStyle(activeColor)
                 Spacer()
                 Toggle(isOn: $state.isEnabled) {
                     Text("ON")
                         .font(.system(size: 10, weight: .bold, design: .monospaced))
-                        .foregroundStyle(state.isEnabled ? WinampTheme.lcdGlow : WinampTheme.lcdDim)
+                        .foregroundStyle(state.isEnabled ? activeColor : dimColor)
                 }
                 .toggleStyle(.button)
-                .tint(WinampTheme.accent)
+                .tint(activeColor)
                 Toggle(isOn: $state.autoMode) {
                     Text("AUTO")
                         .font(.system(size: 10, weight: .bold, design: .monospaced))
-                        .foregroundStyle(state.autoMode ? WinampTheme.lcdGlow : WinampTheme.lcdDim)
+                        .foregroundStyle(state.autoMode ? activeColor : dimColor)
                 }
                 .toggleStyle(.button)
-                .tint(WinampTheme.accent)
+                .tint(activeColor)
             }
             .padding(.horizontal, 8)
             .padding(.vertical, 4)
@@ -41,10 +46,12 @@ struct SkinnedEqualizerView: View {
 
             // Band sliders + preamp
             HStack(alignment: .bottom, spacing: 6) {
-                bandSlider(title: "PRE", value: $state.preamp, isPreamp: true)
+                bandSlider(title: "PRE", value: $state.preamp, isPreamp: true,
+                           activeColor: activeColor, dimColor: dimColor)
                 Rectangle().fill(Color(white: 0.2)).frame(width: 1)
                 ForEach(bands.indices, id: \.self) { i in
-                    bandSlider(title: bands[i], value: $state.bands[i], isPreamp: false)
+                    bandSlider(title: bands[i], value: $state.bands[i], isPreamp: false,
+                               activeColor: activeColor, dimColor: dimColor)
                 }
             }
             .padding(.horizontal, 8)
@@ -53,21 +60,23 @@ struct SkinnedEqualizerView: View {
             // Footer note
             Text("Visual only — full audio EQ coming with AVAudioEngine")
                 .font(.system(size: 9, design: .monospaced))
-                .foregroundStyle(WinampTheme.lcdDim)
+                .foregroundStyle(dimColor)
                 .frame(maxWidth: .infinity)
                 .padding(.bottom, 4)
         }
-        .background(Color.black)
+        .background(palette.background)
         .overlay(Rectangle().stroke(Color(white: 0.25), lineWidth: 1))
     }
 
-    private func bandSlider(title: String, value: Binding<Double>, isPreamp: Bool) -> some View {
+    private func bandSlider(title: String, value: Binding<Double>, isPreamp: Bool,
+                            activeColor: Color, dimColor: Color) -> some View {
         VStack(spacing: 2) {
-            VerticalDbSlider(value: value, enabled: state.isEnabled)
+            VerticalDbSlider(value: value, enabled: state.isEnabled,
+                             activeColor: activeColor, dimColor: dimColor)
                 .frame(width: 22, height: 90)
             Text(title)
                 .font(.system(size: 9, weight: .bold, design: .monospaced))
-                .foregroundStyle(isPreamp ? WinampTheme.accent : (state.isEnabled ? WinampTheme.lcdGlow : WinampTheme.lcdDim))
+                .foregroundStyle(isPreamp ? activeColor : (state.isEnabled ? activeColor : dimColor))
         }
     }
 }
@@ -78,6 +87,8 @@ struct SkinnedEqualizerView: View {
 private struct VerticalDbSlider: View {
     @Binding var value: Double // -1...1, center 0 = 0 dB
     var enabled: Bool
+    var activeColor: Color
+    var dimColor: Color
 
     var body: some View {
         GeometryReader { geo in
@@ -98,16 +109,16 @@ private struct VerticalDbSlider: View {
 
                 // Center 0 dB line
                 Rectangle()
-                    .fill(WinampTheme.lcdDim.opacity(0.4))
+                    .fill(dimColor.opacity(0.5))
                     .frame(width: w, height: 1)
                     .offset(x: 0, y: centerY)
 
                 // Knob
                 RoundedRectangle(cornerRadius: 2)
-                    .fill(enabled ? WinampTheme.lcdGlow : WinampTheme.lcdDim)
+                    .fill(enabled ? activeColor : dimColor)
                     .frame(width: w, height: knobH)
                     .offset(x: 0, y: knobY)
-                    .shadow(color: enabled ? WinampTheme.lcdGlow.opacity(0.5) : .clear, radius: 2)
+                    .shadow(color: enabled ? activeColor.opacity(0.5) : .clear, radius: 2)
             }
             .contentShape(Rectangle())
             .gesture(

--- a/HarmonIQ/Views/Skin/SkinnedPlaylistView.swift
+++ b/HarmonIQ/Views/Skin/SkinnedPlaylistView.swift
@@ -2,35 +2,40 @@ import SwiftUI
 
 /// Winamp-style playlist editor: shows the current play queue as a tight,
 /// monospaced list. The currently playing row is highlighted; tapping a row
-/// jumps playback to that track.
+/// jumps playback to that track. Colors track the active skin's PLEDIT.TXT
+/// palette (normal text, current track text, selected background); falls
+/// back to WinampTheme defaults when no skin is active.
 struct SkinnedPlaylistView: View {
     @EnvironmentObject var player: AudioPlayerManager
+    @EnvironmentObject var skinManager: SkinManager
 
     var body: some View {
+        let palette = SkinPalette(skin: skinManager.activeSkin)
+
         VStack(spacing: 0) {
             // Title bar
             HStack {
                 Text("PLAYLIST EDITOR")
                     .font(.system(size: 11, weight: .bold, design: .monospaced))
-                    .foregroundStyle(WinampTheme.lcdGlow)
+                    .foregroundStyle(palette.current)
                     .padding(.horizontal, 8)
                 Spacer()
                 Text("\(player.queue.count) tracks")
                     .font(.system(size: 10, design: .monospaced))
-                    .foregroundStyle(WinampTheme.lcdDim)
+                    .foregroundStyle(palette.normal.opacity(0.7))
                     .padding(.horizontal, 8)
             }
             .padding(.vertical, 4)
             .background(LinearGradient(colors: [Color(white: 0.18), Color(white: 0.10)], startPoint: .top, endPoint: .bottom))
 
             if player.queue.isEmpty {
-                emptyState
+                emptyState(palette: palette)
             } else {
                 ScrollViewReader { proxy in
                     ScrollView {
                         LazyVStack(alignment: .leading, spacing: 0) {
                             ForEach(Array(player.queue.enumerated()), id: \.offset) { idx, track in
-                                row(idx: idx, track: track)
+                                row(idx: idx, track: track, palette: palette)
                                     .id(idx)
                             }
                         }
@@ -41,18 +46,18 @@ struct SkinnedPlaylistView: View {
                 }
             }
         }
-        .background(Color.black)
+        .background(palette.background)
         .overlay(
             Rectangle().stroke(Color(white: 0.25), lineWidth: 1)
         )
     }
 
-    private var emptyState: some View {
+    private func emptyState(palette: SkinPalette) -> some View {
         VStack(spacing: 6) {
             Spacer()
             Text("Queue is empty")
                 .font(.system(size: 12, design: .monospaced))
-                .foregroundStyle(WinampTheme.lcdDim)
+                .foregroundStyle(palette.normal.opacity(0.7))
             Text("Pick a track from the Library tab to start playback.")
                 .font(.system(size: 10, design: .monospaced))
                 .foregroundStyle(.secondary)
@@ -63,29 +68,30 @@ struct SkinnedPlaylistView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    private func row(idx: Int, track: Track) -> some View {
+    private func row(idx: Int, track: Track, palette: SkinPalette) -> some View {
         let isCurrent = idx == player.currentIndex
+        let textColor = isCurrent ? palette.current : palette.normal
         return Button {
             player.play(track: track, in: player.queue)
         } label: {
             HStack(spacing: 8) {
                 Text(String(format: "%2d.", idx + 1))
                     .font(.system(size: 11, design: .monospaced))
-                    .foregroundStyle(isCurrent ? WinampTheme.lcdGlow : WinampTheme.lcdDim)
+                    .foregroundStyle(textColor.opacity(isCurrent ? 1 : 0.75))
                     .frame(width: 28, alignment: .trailing)
                 Text("\(track.displayArtist) – \(track.displayTitle)")
                     .font(.system(size: 11, design: .monospaced))
-                    .foregroundStyle(isCurrent ? WinampTheme.lcdGlow : Color(white: 0.85))
+                    .foregroundStyle(textColor)
                     .lineLimit(1)
                     .truncationMode(.tail)
                 Spacer(minLength: 8)
                 Text(formatDuration(track.duration))
                     .font(.system(size: 11, design: .monospaced))
-                    .foregroundStyle(isCurrent ? WinampTheme.lcdGlow : WinampTheme.lcdDim)
+                    .foregroundStyle(textColor.opacity(isCurrent ? 1 : 0.75))
             }
             .padding(.horizontal, 8)
             .padding(.vertical, 3)
-            .background(isCurrent ? Color(white: 0.12) : Color.clear)
+            .background(isCurrent ? palette.selectedBackground : Color.clear)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -95,5 +101,28 @@ struct SkinnedPlaylistView: View {
         guard seconds.isFinite, seconds > 0 else { return "--:--" }
         let total = Int(seconds.rounded())
         return String(format: "%d:%02d", total / 60, total % 60)
+    }
+}
+
+/// Resolves the active skin's PLEDIT.TXT palette into SwiftUI Colors with sensible
+/// fallbacks for the no-skin (None) case so panels stay readable in either mode.
+struct SkinPalette {
+    let normal: Color
+    let current: Color
+    let background: Color
+    let selectedBackground: Color
+
+    init(skin: WinampSkin?) {
+        if let s = skin {
+            self.normal = Color(uiColor: s.playlistColors.normal)
+            self.current = Color(uiColor: s.playlistColors.current)
+            self.background = Color(uiColor: s.playlistColors.normalBG)
+            self.selectedBackground = Color(uiColor: s.playlistColors.selectedBG)
+        } else {
+            self.normal = Color(white: 0.85)
+            self.current = WinampTheme.lcdGlow
+            self.background = Color.black
+            self.selectedBackground = Color(white: 0.12)
+        }
     }
 }


### PR DESCRIPTION
Three real-iPhone bugs:

## 1. Mini player blocked the bottom row
`ContentView` pinned a `MiniPlayerView` via `.safeAreaInset(edge: .bottom)` when a track was loaded. After dismissing the now-playing sheet, the mini player covered any UI in the bottom row (tab bar items, list rows, etc.) and made them unreachable. Removed the `.safeAreaInset` block entirely. Auto-present-on-track-tap (from PR #5) already handles reopening the sheet, so no persistent control is lost — dismiss and tap any track to bring the player back.

## 2. EQ + Playlist panels didn't track the active skin
`SkinnedPlaylistView` and `SkinnedEqualizerView` used hardcoded `WinampTheme` colors. Switching skins changed the main player canvas only, leaving the panels stuck on the lime-LCD palette regardless of which skin was active. Introduced a `SkinPalette` helper that resolves `WinampSkin.playlistColors` (parsed from PLEDIT.TXT at load time — already in `WinampSkin`) into SwiftUI `Color`s, with `WinampTheme` fallbacks for the no-skin (None) case. Both panels now read the palette per-render via `@EnvironmentObject SkinManager`, so skin switches propagate immediately. The vertical EQ slider gains `activeColor`/`dimColor` parameters wired to the palette.

## 3. Couldn't switch back to a skin from the SwiftUI player
After picking *None (SwiftUI player)* from any skin picker, the now-playing sheet swaps to `NowPlayingView`, which had no skin picker — so once on the SwiftUI player, the only way to return to a skinned player was *Settings → Appearance → Skins*. Added the same paintpalette `Menu` next to the grab handle on `NowPlayingView` (full skin list with None + every installed skin, checkmark on the active one, wired to `SkinManager.selectSkin` / `clearSkin`).

## Test plan
- [ ] Play a track, dismiss the sheet → confirm the bottom rows of every tab are no longer covered.
- [ ] Re-tap any track → sheet reopens (auto-present still works).
- [ ] In the skinned player, switch skins via the paintpalette menu → confirm the main canvas, EQ panel, and Playlist panel all recolor at once.
- [ ] Pick *None* → SwiftUI player appears; tap its paintpalette icon → swap to a different skin → skinned player returns and remembers across launches.
- [ ] Confirm the bundled skins (Base 2.91, Green Dimension, Internet Archive, MacOSX Aqua, TopazAmp) each show distinguishable EQ/Playlist colors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)