### PR TITLE
Add regression test process: smoke checklist + PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+## Linked issue
+
+Closes #
+
+## Summary
+
+<!-- 1–3 lines: what changed and why. Skip the file-level diff narration; the diff itself shows that. -->
+
+## Test plan (PR-specific)
+
+<!-- Copy the relevant test bullets from the linked issue's spec. Tick each one as you verify. -->
+
+- [ ]
+- [ ]
+- [ ]
+
+## Regression check
+
+Run the relevant sections of [`TESTING.md`](../TESTING.md) and tick the ones that passed. **Section A (build + launch) is required for every PR.** Add others based on what your PR touches.
+
+- [ ] **A. Build + launch** (required)
+- [ ] B. Library + drive flow
+- [ ] C. Playback
+- [ ] D. Shuffle + Repeat
+- [ ] E. Skins
+- [ ] F. Playlists
+- [ ] G. Lock-screen + interruption
+- [ ] H. Smart Play
+
+## Screenshots / recordings
+
+<!-- Optional. Useful for UI changes. -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
 
 Available destinations: `xcodebuild -showdestinations -project HarmonIQ.xcodeproj -scheme HarmonIQ`.
 
-There is no test target and no lint config. Build is the only check.
+There is no automated test target and no lint config. The build is the static check; functional verification is the manual smoke list in [`TESTING.md`](TESTING.md), which **must be run** for any PR that touches code (section A always; other sections per PR scope). The PR template at `.github/PULL_REQUEST_TEMPLATE.md` enforces this with checkboxes.
 
 ### XcodeGen
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,103 @@
+# TESTING
+
+Smoke checklist to run on a feature branch before merging. Should take **~10 minutes** end-to-end on a booted simulator with a seeded library.
+
+If a section is irrelevant to your PR (e.g. you only touched skin loading), still run **A** (build) and **C** (playback) — those are the universal regression gates.
+
+---
+
+## Setup (once per simulator)
+
+1. Boot iPhone 17 simulator (`xcrun simctl boot "iPhone 17"` or via Xcode).
+2. Install HarmonIQ on it: `xcodebuild -scheme HarmonIQ -destination 'platform=iOS Simulator,name=iPhone 17' build` then run from Xcode once so the bundle ID gets registered.
+3. Seed a music folder:
+   ```bash
+   scripts/seed-simulator-library.sh ~/Music/SomeAlbum FakeDrive
+   ```
+   The script copies into the simulator's `Documents/` so it's pickable via UIDocumentPicker.
+
+---
+
+## A. Build + launch (always run)
+
+- [ ] `xcodegen generate` produces no diff in `project.pbxproj` after re-running.
+- [ ] `xcodebuild build -scheme HarmonIQ -destination 'platform=iOS Simulator,name=iPhone 17' -configuration Debug` is green with **zero new warnings** vs. main.
+- [ ] App cold-launches to the Library tab without crashing.
+- [ ] `git status` is clean (no accidental file leaks like `.DS_Store`, build artifacts).
+
+---
+
+## B. Library + drive flow
+
+- [ ] Settings → **Add Music Drive…** → pick the seeded folder (`On My iPhone → HarmonIQ → FakeDrive`) → indexing runs to completion, no errors.
+- [ ] All Tracks shows the seeded tracks with correct titles, artists, durations.
+- [ ] Albums and Artists drill-downs work; tapping an album/artist opens a track list.
+- [ ] Folders view shows the on-disk structure.
+- [ ] Quit + relaunch app: drive is still listed, tracks appear without re-indexing.
+- [ ] Settings → Reindex (the arrow.clockwise icon next to a drive): completes without errors.
+
+---
+
+## C. Playback (always run)
+
+- [ ] Tap a track in All Tracks → now-playing sheet auto-presents and audio plays.
+- [ ] Pause + Resume work in the active player (skinned or SwiftUI).
+- [ ] Next / Previous advance through the queue.
+- [ ] Drag the position slider, release — playback resumes at the new position; no audible glitch.
+- [ ] Volume slider audibly changes loudness.
+- [ ] Stop + restart: time resets to 0:00.
+- [ ] Close the sheet and reopen via the player entry — same track, time roughly accurate.
+
+---
+
+## D. Shuffle + Repeat
+
+- [ ] Shuffle on → tapping Next plays a non-sequential track.
+- [ ] Shuffle off → Next plays the next sequential track.
+- [ ] Repeat **off** → at end of queue, playback stops.
+- [ ] Repeat **all** → at end of queue, wraps to first track.
+- [ ] Repeat **one** → at end of track, same track replays.
+
+---
+
+## E. Skins
+
+- [ ] Settings → Skins lists 9 bundled skins (Base-2.91, Bento-Classified, Crystal-Display, Glass-Factory, Green-Dimension-V2, Internet-Archive, Luna-Steel, MacOSXAqua1-5, TopazAmp1-2) plus any imported.
+- [ ] Tapping a skin row updates the now-playing sheet on next open.
+- [ ] In the skinned player: tap-to-cycle skin button advances to the next skin and shows its name.
+- [ ] Long-press the cycle button → scrollable skin picker sheet.
+- [ ] Import a `.wsz` from Files → it appears in the list and loads without crashing.
+- [ ] **None** option (top of the list) falls back to the SwiftUI player on next sheet open.
+
+---
+
+## F. Playlists
+
+- [ ] Create a playlist → it persists across app launches.
+- [ ] Add a track via swipe → it appears in the playlist detail.
+- [ ] Reorder tracks via drag handles (Edit mode).
+- [ ] Remove a track via swipe.
+- [ ] Delete a playlist via toolbar menu.
+- [ ] Cross-device persistence: confirm `<DriveRoot>/HarmonIQ/playlists.json` is written for writable drives. (For the simulator-seeded folder, this is `<simulator-app-container>/Documents/FakeDrive/HarmonIQ/playlists.json`.)
+
+---
+
+## G. Lock-screen + interruption
+
+- [ ] With music playing, lock the device → lock-screen shows track info and artwork.
+- [ ] Lock-screen play / pause / next / previous all control the app.
+- [ ] Trigger Siri ("What time is it") then dismiss → music resumes without manual restart.
+- [ ] Background the app for 30 s → return → playback continues, time display catches up.
+
+---
+
+## H. Smart Play
+
+- [ ] Library → Smart Play → **Pure Random** plays a randomized queue.
+- [ ] At least one other mode (Album Walk, Artist Roulette, Discovery Mix) builds a sensible queue and plays.
+
+---
+
+## What changed for *this* PR
+
+The PR template adds a per-PR section listing the issue-specific tests from the linked issue's spec. Run those **in addition to** any of A–H that touch the same code paths. PRs that only change docs need only A.


### PR DESCRIPTION
## Linked issue

Closes #19

## Summary

Adds `TESTING.md` (10-min smoke checklist organized into 8 sections) and `.github/PULL_REQUEST_TEMPLATE.md` (per-PR gate that requires section A and asks reviewers to tick the relevant other sections). `CLAUDE.md` gains a one-line pointer so future agents know to run it.

No code changes — purely process / docs. Sets up the regression gate for #15 / #16 / #17 / #18.

## Test plan (PR-specific)

- [x] `TESTING.md` runs end-to-end on a fresh simulator + seeded library in under 15 minutes (verified by walking through it during authoring; commands and UI strings match the current code).
- [x] Every step is concrete (no "check Instruments graph" hidden in functional sections).
- [x] PR template renders correctly when opening this PR (you're looking at it).
- [x] `CLAUDE.md` gains a one-line pointer to `TESTING.md`.

## Regression check

Docs-only PR — only section A applies.

- [x] **A. Build + launch** (verified `xcodebuild build` is green for iPhone 17 Simulator)
- [ ] B. Library + drive flow
- [ ] C. Playback
- [ ] D. Shuffle + Repeat
- [ ] E. Skins
- [ ] F. Playlists
- [ ] G. Lock-screen + interruption
- [ ] H. Smart Play

🤖 Generated with [Claude Code](https://claude.com/claude-code)