### PR TITLE
Show '1' badge on repeat button for single-track loop

### DIFF
--- a/HarmonIQ/Views/Skin/SkinnedMainView.swift
+++ b/HarmonIQ/Views/Skin/SkinnedMainView.swift
@@ -326,14 +326,28 @@ struct SkinnedMainView: View {
                   width: SkinFormat.MainElement.shuffleButton.width,
                   height: SkinFormat.MainElement.shuffleButton.height)
 
-        // Repeat button
-        SpriteButton(
-            atlas: atlas,
-            normal: player.repeatMode == .off ? SkinFormat.ShufRep.repeatOff : SkinFormat.ShufRep.repeatOn,
-            pressed: player.repeatMode == .off ? SkinFormat.ShufRep.repeatOffDown : SkinFormat.ShufRep.repeatOnDown,
-            pixelSize: pixel
-        ) {
-            player.cycleRepeatMode()
+        // Repeat button — three states: off / all / one. The classic shufrep.bmp
+        // only ships off/on sprites, so we overlay a small "1" badge on top of
+        // the on-state when in single-track loop. This is the only way to make
+        // .all visually distinct from .one without a custom sprite per skin.
+        ZStack(alignment: .topTrailing) {
+            SpriteButton(
+                atlas: atlas,
+                normal: player.repeatMode == .off ? SkinFormat.ShufRep.repeatOff : SkinFormat.ShufRep.repeatOn,
+                pressed: player.repeatMode == .off ? SkinFormat.ShufRep.repeatOffDown : SkinFormat.ShufRep.repeatOnDown,
+                pixelSize: pixel
+            ) {
+                player.cycleRepeatMode()
+            }
+            if player.repeatMode == .one {
+                Text("1")
+                    .font(.system(size: max(8, 5 * pixel), weight: .heavy, design: .monospaced))
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, max(2, 1 * pixel))
+                    .background(Color.black.opacity(0.8), in: Capsule())
+                    .allowsHitTesting(false)
+                    .padding(max(1, 1 * pixel))
+            }
         }
         .position(at: SkinFormat.MainElement.repeatButton.origin, pixel: pixel,
                   width: SkinFormat.MainElement.repeatButton.width,


### PR DESCRIPTION
## Linked issue

Closes #15

## Summary

`AudioPlayerManager` already cycles `repeatMode` through `.off → .all → .one → .off` and handles each correctly at end-of-track (replay for `.one`, wrap for `.all`, stop for `.off`). The skinned player's repeat button was calling `cycleRepeatMode()` on tap, but the `shufrep.bmp` atlas only ships off/on sprites — so `.all` and `.one` rendered identically. Added a small non-interactive monospaced "1" badge over the on-state when in `.one` mode to disambiguate. SwiftUI fallback already handled this with the `repeat.1` SF Symbol.

Pure visual fix — no audio/queue logic changed.

## Test plan (PR-specific)

### Logic (verified by inspection — no test target yet)

- [x] `cycleRepeatMode()` cycles `.off → .all → .one → .off` (AudioPlayerManager.swift:160).
- [x] `toggleShuffle()` flips `isShuffleEnabled`; `didSet` triggers `rebuildPlayOrderIfNeeded` which produces a randomized `playOrder`.
- [x] `audioPlayerDidFinishPlaying`: `.one` → `playCurrent()` (replays); else → `advance(by: 1)`.
- [x] `advance(by:)` for `.all` at queue end → wraps via `((proposed % queue.count) + queue.count) % queue.count`.
- [x] `advance(by:)` for `.off` at queue end → calls `pause()`.

### Manual (run on simulator with seeded library)

- [ ] Open skinned player. Tap shuffle. Sprite changes to "on". Tap Next a few times — order is randomized.
- [ ] Tap shuffle again. Sprite returns to "off". Next plays the next sequential track.
- [ ] Tap repeat once. Sprite shows "on", **no "1" badge** visible. Let track end → next track plays. At queue end → wraps to first.
- [ ] Tap repeat again. Sprite still "on", **"1" badge visible** in top-right. Let track end → same track restarts.
- [ ] Tap repeat again. Sprite returns to "off". At queue end → playback stops.
- [ ] Switch to a different skin (e.g. Internet-Archive); both buttons still render correctly, badge still visible when in `.one`.
- [ ] Settings → Skins → "None" (SwiftUI fallback): shuffle/repeat icons cycle correctly (repeat icon swaps to `repeat.1` for `.one`).
- [ ] Tap test on the badge area: tap goes through to the underlying repeat button (badge has `allowsHitTesting(false)`).

## Regression check

- [x] **A. Build + launch** — `xcodebuild build` green, zero new warnings.
- [ ] B. Library + drive flow — not touched by this PR.
- [ ] C. Playback — please verify Play / Pause / Stop / Prev / Next / seek still work.
- [ ] D. Shuffle + Repeat — covered by the manual checklist above.
- [ ] E. Skins — please switch between a few skins and confirm the badge renders cleanly across them.
- [ ] F. Playlists — not touched.
- [ ] G. Lock-screen — please confirm lock-screen controls still work.
- [ ] H. Smart Play — not touched.

## Screenshots / recordings

Worth a screenshot in `.one` mode to confirm the "1" badge sits cleanly in the top-right of the repeat button across a few skins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)