### PR TITLE
Bump to 0.3 (build 2) and add DEVELOPMENT_TEAM for TestFlight

### DIFF
--- a/HarmonIQ/Info.plist
+++ b/HarmonIQ/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>0.3</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSSupportsOpeningDocumentsInPlace</key>
 	<true/>
 	<key>NSAppleMusicUsageDescription</key>

--- a/project.yml
+++ b/project.yml
@@ -16,6 +16,7 @@ settings:
     DEVELOPMENT_LANGUAGE: en
     ENABLE_USER_SCRIPT_SANDBOXING: NO
     CODE_SIGN_STYLE: Automatic
+    DEVELOPMENT_TEAM: 79DDZ6D8WT
     GENERATE_INFOPLIST_FILE: NO
 targets:
   HarmonIQ:
@@ -40,8 +41,8 @@ targets:
       path: HarmonIQ/Info.plist
       properties:
         CFBundleDisplayName: HarmonIQ
-        CFBundleShortVersionString: "1.0"
-        CFBundleVersion: "1"
+        CFBundleShortVersionString: "0.3"
+        CFBundleVersion: "2"
         UILaunchScreen:
           UIColorName: AccentColor
         UIBackgroundModes:


### PR DESCRIPTION
Prep for the first TestFlight upload of v0.3:

- project.yml + HarmonIQ/Info.plist: CFBundleShortVersionString bumped from 1.0 -> 0.3 to match the GitHub release tag, build bumped to 2 (build 1 was consumed by an earlier failed validation)
- project.yml: DEVELOPMENT_TEAM = 79DDZ6D8WT in shared base settings so xcodegen-regenerated .pbxproj keeps the team set under CODE_SIGN_STYLE = Automatic. Without this, regenerating would wipe the team and break archive signing.

Build 0.3 (2) is uploaded and Waiting for Review on App Store Connect (HarmonIQ Music Player, Apple ID 6765739658). No code changes; pure project metadata.

## Linked issue

Closes #

## Summary

<!-- 1–3 lines: what changed and why. Skip the file-level diff narration; the diff itself shows that. -->

## Test plan (PR-specific)

<!-- Copy the relevant test bullets from the linked issue's spec. Tick each one as you verify. -->

- [ ]
- [ ]
- [ ]

## Regression check

Run the relevant sections of [`TESTING.md`](../TESTING.md) and tick the ones that passed. **Section A (build + launch) is required for every PR.** Add others based on what your PR touches.

- [ ] **A. Build + launch** (required)
- [ ] B. Library + drive flow
- [ ] C. Playback
- [ ] D. Shuffle + Repeat
- [ ] E. Skins
- [ ] F. Playlists
- [ ] G. Lock-screen + interruption
- [ ] H. Smart Play

## Screenshots / recordings

<!-- Optional. Useful for UI changes. -->
