### PR TITLE
Sleep timer: auto-stop after fixed duration or end of track

### DIFF
--- a/HarmonIQ.xcodeproj/project.pbxproj
+++ b/HarmonIQ.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		16F8F24D50C9EB96562011DC /* SmartPlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = A31A65F1BCE09BD374018CC4 /* SmartPlay.swift */; };
 		378FEA2A2125F0710167C4EE /* ScrollingBitmapText.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB566E7DBDC9F95DA534869C /* ScrollingBitmapText.swift */; };
 		3A5F09869BC9EA7F4DC88B35 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D6EA2A86E18C3306B3A4BFC /* ContentView.swift */; };
+		3C97B812BAD6F65814E216E6 /* SleepTimerViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C45ED4E273D5CD36352156 /* SleepTimerViews.swift */; };
 		3EE13B1011444446AF4C9346 /* MusicIndexer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D861E89EB0B0713F92113EE /* MusicIndexer.swift */; };
 		409179BD52B576D6D435FD06 /* NowPlayingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B633D01EE0A630588055E78D /* NowPlayingManager.swift */; };
 		4ADB0C6545C514B0C7DD74BC /* SkinManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4AF615B9FD22338A53B687E /* SkinManager.swift */; };
@@ -33,16 +34,16 @@
 		9546DB969B9FE4BEBDBF9F76 /* FoldersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E35D430429E1AB1C5D29D971 /* FoldersView.swift */; };
 		95C1D7862712B1AF3530D399 /* SkinFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982616423A6BC3BB174F0A2E /* SkinFormat.swift */; };
 		A10BD1CC54DC77E7DF551BA6 /* LibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CA5D219A5FF2CBA19A0E003 /* LibraryView.swift */; };
-		A93B5C6D7E8F90A1B2C3D4E5 /* SandboxRootStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F1A8B2D9C3E4F5061728394 /* SandboxRootStore.swift */; };
 		A9D09BD270A0DB94DD3F50C4 /* SkinnedMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A690CB3BB86B25F3B2E899 /* SkinnedMainView.swift */; };
+		AC478B855CF2B75C21361D45 /* SandboxRootStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F220F64AA1D95133ED5A5159 /* SandboxRootStore.swift */; };
+		AC921564D73DC6AE631081AE /* SkinnedPlaylistView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A766E8A1DB63DED492B821BA /* SkinnedPlaylistView.swift */; };
 		ADFA445F84DD3EDB1A55C5DB /* WinampSkin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BBB248B178FE1FCF612ED97 /* WinampSkin.swift */; };
 		B5EE909DC0FD5E4684D545F9 /* Skins in Resources */ = {isa = PBXBuildFile; fileRef = 7D9E86967B7801F70269E055 /* Skins */; };
 		BFEC72EA12BDE9A75C6FFEB2 /* SkinnedVisualizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D68585262E7BD5EBB3CDF779 /* SkinnedVisualizer.swift */; };
-		C1D2E3F405061718292A3B4C /* SkinnedPlaylistView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E3F405061718292A3B4C5D /* SkinnedPlaylistView.swift */; };
-		C2E3F405061718292A3B4C5D /* SkinnedEqualizerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3F405061718292A3B4C5D6E /* SkinnedEqualizerView.swift */; };
 		C7F097C03E3F811A8FFD64F6 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F01297D60CC5B6C050170B45 /* Preview Assets.xcassets */; };
 		CBDFA717362848840E08B642 /* BitmapText.swift in Sources */ = {isa = PBXBuildFile; fileRef = F995634B51E300AA46B6DBF7 /* BitmapText.swift */; };
 		CE1BF955311C8DB60D692FE8 /* NowPlayingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38FE23F9FF831246E93D46D0 /* NowPlayingView.swift */; };
+		D0B58783C53C00AAF777EA5B /* SkinnedEqualizerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91184AF88772B10074EACE0A /* SkinnedEqualizerView.swift */; };
 		D14CC8746BAA04AFF959DFB5 /* MetadataExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53B7620084258E7F659C7D7 /* MetadataExtractor.swift */; };
 		D2EA2CFCD49E1790A8904149 /* WinampTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A34D43E2D09B36F9A92DF67 /* WinampTheme.swift */; };
 		DA3451E853523F3F3794A302 /* ArtistsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D6E4A738A357E6A860D0E0 /* ArtistsView.swift */; };
@@ -55,6 +56,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		03C45ED4E273D5CD36352156 /* SleepTimerViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepTimerViews.swift; sourceTree = "<group>"; };
 		21D6E4A738A357E6A860D0E0 /* ArtistsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistsView.swift; sourceTree = "<group>"; };
 		32550B9D7779BCA0DDA5827D /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
 		347E6294D599CCE0B3003D2E /* SharedComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedComponents.swift; sourceTree = "<group>"; };
@@ -67,9 +69,9 @@
 		645788E38767A20E50B440A4 /* SkinnedVolumeSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkinnedVolumeSlider.swift; sourceTree = "<group>"; };
 		6A922A09FC20BC24E0180727 /* Visualizers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Visualizers.swift; sourceTree = "<group>"; };
 		6E48BCF53895F042489D6F8B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-		6F1A8B2D9C3E4F5061728394 /* SandboxRootStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxRootStore.swift; sourceTree = "<group>"; };
 		7D9E86967B7801F70269E055 /* Skins */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Skins; path = HarmonIQ/Resources/Skins; sourceTree = SOURCE_ROOT; };
 		8CA5D219A5FF2CBA19A0E003 /* LibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryView.swift; sourceTree = "<group>"; };
+		91184AF88772B10074EACE0A /* SkinnedEqualizerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkinnedEqualizerView.swift; sourceTree = "<group>"; };
 		978941B5C224F0EFA9E46A90 /* AudioPlayerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPlayerManager.swift; sourceTree = "<group>"; };
 		982616423A6BC3BB174F0A2E /* SkinFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkinFormat.swift; sourceTree = "<group>"; };
 		9BA0C5DAF97A47E057019501 /* BookmarkStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkStore.swift; sourceTree = "<group>"; };
@@ -78,6 +80,7 @@
 		9F130079612D4D04F3BDAF75 /* LibraryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryStore.swift; sourceTree = "<group>"; };
 		A31A65F1BCE09BD374018CC4 /* SmartPlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartPlay.swift; sourceTree = "<group>"; };
 		A4AF615B9FD22338A53B687E /* SkinManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkinManager.swift; sourceTree = "<group>"; };
+		A766E8A1DB63DED492B821BA /* SkinnedPlaylistView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkinnedPlaylistView.swift; sourceTree = "<group>"; };
 		AA4029B61958E1D8F6162CCA /* HarmonIQApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarmonIQApp.swift; sourceTree = "<group>"; };
 		AC1C8025A0B96CB360C84D6A /* SkinLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkinLoader.swift; sourceTree = "<group>"; };
 		AF43538DAF9F07E1F7428FE1 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
@@ -85,20 +88,19 @@
 		BAE503899DE0AC71DEE6E6B7 /* SmartPlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartPlayView.swift; sourceTree = "<group>"; };
 		BB566E7DBDC9F95DA534869C /* ScrollingBitmapText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollingBitmapText.swift; sourceTree = "<group>"; };
 		BEFB4D3197C2EC465A4B964C /* DriveLibraryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DriveLibraryStore.swift; sourceTree = "<group>"; };
-		C20AD805166CAC672F2833BC /* HarmonIQ.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HarmonIQ.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		C20AD805166CAC672F2833BC /* HarmonIQ.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = HarmonIQ.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C4D685B9A89C2B6EDCCCB4AB /* AlbumsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumsView.swift; sourceTree = "<group>"; };
 		C6203F24B0D3D962883456DA /* SpriteButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpriteButton.swift; sourceTree = "<group>"; };
 		CE5341339CB5BD57C71DD7EC /* BitmapSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitmapSlider.swift; sourceTree = "<group>"; };
 		D0243B50E58BF70DF26D99D0 /* AllTracksView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllTracksView.swift; sourceTree = "<group>"; };
 		D210ACF5D89E9E21A1496719 /* Playlist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Playlist.swift; sourceTree = "<group>"; };
-		D2E3F405061718292A3B4C5D /* SkinnedPlaylistView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkinnedPlaylistView.swift; sourceTree = "<group>"; };
 		D68585262E7BD5EBB3CDF779 /* SkinnedVisualizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkinnedVisualizer.swift; sourceTree = "<group>"; };
 		DCC1E5260F8BCC82F22321CD /* Track.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Track.swift; sourceTree = "<group>"; };
 		E35D430429E1AB1C5D29D971 /* FoldersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoldersView.swift; sourceTree = "<group>"; };
-		E3F405061718292A3B4C5D6E /* SkinnedEqualizerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkinnedEqualizerView.swift; sourceTree = "<group>"; };
 		ED17D95227132C92484D37D4 /* BitmapNumbers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitmapNumbers.swift; sourceTree = "<group>"; };
 		F01297D60CC5B6C050170B45 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		F1A690CB3BB86B25F3B2E899 /* SkinnedMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkinnedMainView.swift; sourceTree = "<group>"; };
+		F220F64AA1D95133ED5A5159 /* SandboxRootStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxRootStore.swift; sourceTree = "<group>"; };
 		F53B7620084258E7F659C7D7 /* MetadataExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataExtractor.swift; sourceTree = "<group>"; };
 		F995634B51E300AA46B6DBF7 /* BitmapText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitmapText.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -122,9 +124,9 @@
 				CE5341339CB5BD57C71DD7EC /* BitmapSlider.swift */,
 				F995634B51E300AA46B6DBF7 /* BitmapText.swift */,
 				BB566E7DBDC9F95DA534869C /* ScrollingBitmapText.swift */,
+				91184AF88772B10074EACE0A /* SkinnedEqualizerView.swift */,
 				F1A690CB3BB86B25F3B2E899 /* SkinnedMainView.swift */,
-				D2E3F405061718292A3B4C5D /* SkinnedPlaylistView.swift */,
-				E3F405061718292A3B4C5D6E /* SkinnedEqualizerView.swift */,
+				A766E8A1DB63DED492B821BA /* SkinnedPlaylistView.swift */,
 				D68585262E7BD5EBB3CDF779 /* SkinnedVisualizer.swift */,
 				645788E38767A20E50B440A4 /* SkinnedVolumeSlider.swift */,
 				C6203F24B0D3D962883456DA /* SpriteButton.swift */,
@@ -192,6 +194,7 @@
 				AF43538DAF9F07E1F7428FE1 /* SettingsView.swift */,
 				347E6294D599CCE0B3003D2E /* SharedComponents.swift */,
 				5CC7D5B7F672E031A0E10CD5 /* SkinSettingsView.swift */,
+				03C45ED4E273D5CD36352156 /* SleepTimerViews.swift */,
 				BAE503899DE0AC71DEE6E6B7 /* SmartPlayView.swift */,
 				6A922A09FC20BC24E0180727 /* Visualizers.swift */,
 				4A34D43E2D09B36F9A92DF67 /* WinampTheme.swift */,
@@ -231,7 +234,7 @@
 				9BA0C5DAF97A47E057019501 /* BookmarkStore.swift */,
 				BEFB4D3197C2EC465A4B964C /* DriveLibraryStore.swift */,
 				9F130079612D4D04F3BDAF75 /* LibraryStore.swift */,
-				6F1A8B2D9C3E4F5061728394 /* SandboxRootStore.swift */,
+				F220F64AA1D95133ED5A5159 /* SandboxRootStore.swift */,
 			);
 			path = Persistence;
 			sourceTree = "<group>";
@@ -288,6 +291,7 @@
 				LastUpgradeCheck = 1500;
 				TargetAttributes = {
 					997BB83076AD67261C4AB37C = {
+						DevelopmentTeam = 79DDZ6D8WT;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -342,7 +346,6 @@
 				7F8EEECCAE52592D4BBAF6D1 /* BookmarkStore.swift in Sources */,
 				3A5F09869BC9EA7F4DC88B35 /* ContentView.swift in Sources */,
 				DC9F3F437F7B059AD8D253B5 /* DriveLibraryStore.swift in Sources */,
-				A93B5C6D7E8F90A1B2C3D4E5 /* SandboxRootStore.swift in Sources */,
 				9546DB969B9FE4BEBDBF9F76 /* FoldersView.swift in Sources */,
 				DAC622E13BE984A57D2E9C86 /* HarmonIQApp.swift in Sources */,
 				5DB383E665EE8EAE33D78E9C /* LibraryStore.swift in Sources */,
@@ -353,6 +356,7 @@
 				CE1BF955311C8DB60D692FE8 /* NowPlayingView.swift in Sources */,
 				4F0642BBF49AF0AD060D3949 /* Playlist.swift in Sources */,
 				8E0DD1135723468147BBB31D /* PlaylistsView.swift in Sources */,
+				AC478B855CF2B75C21361D45 /* SandboxRootStore.swift in Sources */,
 				378FEA2A2125F0710167C4EE /* ScrollingBitmapText.swift in Sources */,
 				F01E667FD20EFB46CB5AF202 /* SearchView.swift in Sources */,
 				01E3439E649010D829D7AB8A /* SettingsView.swift in Sources */,
@@ -361,11 +365,12 @@
 				8EA86E02734B08EA09994A4C /* SkinLoader.swift in Sources */,
 				4ADB0C6545C514B0C7DD74BC /* SkinManager.swift in Sources */,
 				77D9EEF75A3909296BEF427B /* SkinSettingsView.swift in Sources */,
+				D0B58783C53C00AAF777EA5B /* SkinnedEqualizerView.swift in Sources */,
 				A9D09BD270A0DB94DD3F50C4 /* SkinnedMainView.swift in Sources */,
-				C1D2E3F405061718292A3B4C /* SkinnedPlaylistView.swift in Sources */,
-				C2E3F405061718292A3B4C5D /* SkinnedEqualizerView.swift in Sources */,
+				AC921564D73DC6AE631081AE /* SkinnedPlaylistView.swift in Sources */,
 				BFEC72EA12BDE9A75C6FFEB2 /* SkinnedVisualizer.swift in Sources */,
 				89D7DBC59590AF415A3B0191 /* SkinnedVolumeSlider.swift in Sources */,
+				3C97B812BAD6F65814E216E6 /* SleepTimerViews.swift in Sources */,
 				16F8F24D50C9EB96562011DC /* SmartPlay.swift in Sources */,
 				77B3E1181A2A2CBFAD277C5E /* SmartPlayView.swift in Sources */,
 				69A2102040E365274784D9BD /* SpriteButton.swift in Sources */,
@@ -416,6 +421,7 @@
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_LANGUAGE = en;
+				DEVELOPMENT_TEAM = 79DDZ6D8WT;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -453,7 +459,6 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEVELOPMENT_ASSET_PATHS = "\"HarmonIQ/Resources/Preview Content\"";
-				DEVELOPMENT_TEAM = 79DDZ6D8WT;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = HarmonIQ/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
@@ -475,7 +480,6 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEVELOPMENT_ASSET_PATHS = "\"HarmonIQ/Resources/Preview Content\"";
-				DEVELOPMENT_TEAM = 79DDZ6D8WT;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = HarmonIQ/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
@@ -527,6 +531,7 @@
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_LANGUAGE = en;
+				DEVELOPMENT_TEAM = 79DDZ6D8WT;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;

--- a/HarmonIQ/Player/AudioPlayerManager.swift
+++ b/HarmonIQ/Player/AudioPlayerManager.swift
@@ -46,10 +46,17 @@ final class AudioPlayerManager: NSObject, ObservableObject {
     /// so a track tap immediately opens the Winamp interface.
     @Published private(set) var presentNowPlayingTick: Int = 0
 
+    // MARK: - Sleep timer
+    /// Non-nil when a fixed-duration timer is armed. Nil = no timer.
+    @Published private(set) var sleepTimerEndsAt: Date?
+    /// When true, playback stops at the natural end of the current track.
+    @Published private(set) var sleepStopAtTrackEnd: Bool = false
+
     /// stableIDs of tracks that have started playing in this app session — fuels Discovery Mix.
     private(set) var sessionPlayedIDs: Set<String> = []
 
     private var player: AVAudioPlayer?
+    private var sleepTimer: Timer?
     private var displayLink: CADisplayLink?
     private var accessRoot: URL?
     private var playOrder: [Int] = [] // indexes into queue
@@ -163,6 +170,34 @@ final class AudioPlayerManager: NSObject, ObservableObject {
         case .all: repeatMode = .one
         case .one: repeatMode = .off
         }
+    }
+
+    // MARK: - Sleep timer
+
+    func setSleepTimer(minutes: Int) {
+        cancelSleepTimer()
+        let interval = TimeInterval(minutes * 60)
+        sleepTimerEndsAt = Date().addingTimeInterval(interval)
+        sleepStopAtTrackEnd = false
+        sleepTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: false) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.pause()
+                self?.sleepTimerEndsAt = nil
+                self?.sleepTimer = nil
+            }
+        }
+    }
+
+    func setSleepTimerEndOfTrack() {
+        cancelSleepTimer()
+        sleepStopAtTrackEnd = true
+    }
+
+    func cancelSleepTimer() {
+        sleepTimer?.invalidate()
+        sleepTimer = nil
+        sleepTimerEndsAt = nil
+        sleepStopAtTrackEnd = false
     }
 
     // MARK: - Internals
@@ -367,6 +402,11 @@ final class AudioPlayerManager: NSObject, ObservableObject {
 extension AudioPlayerManager: AVAudioPlayerDelegate {
     nonisolated func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
         Task { @MainActor in
+            if self.sleepStopAtTrackEnd {
+                self.pause()
+                self.sleepStopAtTrackEnd = false
+                return
+            }
             if self.repeatMode == .one {
                 self.playCurrent()
             } else {

--- a/HarmonIQ/Views/NowPlayingView.swift
+++ b/HarmonIQ/Views/NowPlayingView.swift
@@ -160,8 +160,15 @@ struct NowPlayingView: View {
                             .font(.title3)
                     }
                     .chromeButton(pressed: player.repeatMode != .off)
+
+                    SleepTimerButton()
+                        .environmentObject(player)
                 }
                 .padding(.top, 4)
+
+                SleepTimerCountdown()
+                    .environmentObject(player)
+                    .padding(.bottom, 4)
 
                 if let mode = player.activeSmartMode {
                     HStack(spacing: 6) {

--- a/HarmonIQ/Views/Skin/SkinnedMainView.swift
+++ b/HarmonIQ/Views/Skin/SkinnedMainView.swift
@@ -12,6 +12,7 @@ struct SkinnedMainView: View {
 
     @State private var scrubbingPosition: Double? = nil
     @State private var showSkinPicker = false
+    @State private var showSleepMenu = false
 
     var body: some View {
         GeometryReader { geo in
@@ -56,6 +57,9 @@ struct SkinnedMainView: View {
 
                     Spacer()
 
+                    SleepTimerButton()
+                        .environmentObject(player)
+
                     Button {
                         dismiss()
                     } label: {
@@ -75,6 +79,9 @@ struct SkinnedMainView: View {
                         .frame(width: canvasW, height: canvasH, alignment: .topLeading)
                 }
                 .frame(width: canvasW, height: canvasH)
+
+                SleepTimerCountdown()
+                    .environmentObject(player)
 
                 if let err = player.playbackError {
                     HStack(spacing: 6) {

--- a/HarmonIQ/Views/SleepTimerViews.swift
+++ b/HarmonIQ/Views/SleepTimerViews.swift
@@ -1,37 +1,38 @@
 import SwiftUI
 
-/// Clock icon that opens the sleep-timer menu. Works in both the skinned player
+/// Clock icon that opens the sleep-timer picker. Works in both the skinned player
 /// top bar and the SwiftUI NowPlayingView transport row.
+///
+/// Uses confirmationDialog instead of Menu to avoid the _UIReparentingView crash
+/// that SwiftUI's Menu triggers when it is hosted inside a sheet.
 struct SleepTimerButton: View {
     @EnvironmentObject var player: AudioPlayerManager
+    @State private var showDialog = false
 
     var body: some View {
-        Menu {
-            Button("15 minutes") { player.setSleepTimer(minutes: 15) }
-            Button("30 minutes") { player.setSleepTimer(minutes: 30) }
-            Button("45 minutes") { player.setSleepTimer(minutes: 45) }
-            Button("60 minutes") { player.setSleepTimer(minutes: 60) }
-            Divider()
-            Button("End of current track") { player.setSleepTimerEndOfTrack() }
-            if player.sleepTimerEndsAt != nil || player.sleepStopAtTrackEnd {
-                Divider()
-                Button("Cancel timer", role: .destructive) { player.cancelSleepTimer() }
-            }
+        Button {
+            showDialog = true
         } label: {
-            Image(systemName: timerIconName)
+            Image(systemName: "timer")
                 .font(.title2)
                 .foregroundStyle(isActive ? Color.accentColor : .white.opacity(0.85),
                                  .black.opacity(0.6))
         }
         .accessibilityLabel(isActive ? "Sleep timer active" : "Set sleep timer")
+        .confirmationDialog("Sleep Timer", isPresented: $showDialog, titleVisibility: .visible) {
+            Button("15 minutes") { player.setSleepTimer(minutes: 15) }
+            Button("30 minutes") { player.setSleepTimer(minutes: 30) }
+            Button("45 minutes") { player.setSleepTimer(minutes: 45) }
+            Button("60 minutes") { player.setSleepTimer(minutes: 60) }
+            Button("End of current track") { player.setSleepTimerEndOfTrack() }
+            if isActive {
+                Button("Cancel timer", role: .destructive) { player.cancelSleepTimer() }
+            }
+        }
     }
 
     private var isActive: Bool {
         player.sleepTimerEndsAt != nil || player.sleepStopAtTrackEnd
-    }
-
-    private var timerIconName: String {
-        isActive ? "timer" : "timer"
     }
 }
 

--- a/HarmonIQ/Views/SleepTimerViews.swift
+++ b/HarmonIQ/Views/SleepTimerViews.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+
+/// Clock icon that opens the sleep-timer menu. Works in both the skinned player
+/// top bar and the SwiftUI NowPlayingView transport row.
+struct SleepTimerButton: View {
+    @EnvironmentObject var player: AudioPlayerManager
+
+    var body: some View {
+        Menu {
+            Button("15 minutes") { player.setSleepTimer(minutes: 15) }
+            Button("30 minutes") { player.setSleepTimer(minutes: 30) }
+            Button("45 minutes") { player.setSleepTimer(minutes: 45) }
+            Button("60 minutes") { player.setSleepTimer(minutes: 60) }
+            Divider()
+            Button("End of current track") { player.setSleepTimerEndOfTrack() }
+            if player.sleepTimerEndsAt != nil || player.sleepStopAtTrackEnd {
+                Divider()
+                Button("Cancel timer", role: .destructive) { player.cancelSleepTimer() }
+            }
+        } label: {
+            Image(systemName: timerIconName)
+                .font(.title2)
+                .foregroundStyle(isActive ? Color.accentColor : .white.opacity(0.85),
+                                 .black.opacity(0.6))
+        }
+        .accessibilityLabel(isActive ? "Sleep timer active" : "Set sleep timer")
+    }
+
+    private var isActive: Bool {
+        player.sleepTimerEndsAt != nil || player.sleepStopAtTrackEnd
+    }
+
+    private var timerIconName: String {
+        isActive ? "timer" : "timer"
+    }
+}
+
+/// Shows a small LCD-style countdown when a sleep timer is running.
+/// Zero-height when no timer is active so layout stays clean.
+struct SleepTimerCountdown: View {
+    @EnvironmentObject var player: AudioPlayerManager
+
+    var body: some View {
+        Group {
+            if player.sleepStopAtTrackEnd {
+                label(text: "SLEEP: END OF TRACK")
+            } else if let endsAt = player.sleepTimerEndsAt {
+                TimelineView(.periodic(from: .now, by: 1)) { _ in
+                    let remaining = max(0, endsAt.timeIntervalSinceNow)
+                    label(text: "SLEEP: \(formatRemaining(remaining))")
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func label(text: String) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: "timer")
+                .font(.system(size: 11))
+                .foregroundStyle(WinampTheme.lcdGlow)
+            Text(text)
+                .font(WinampTheme.lcdFont(size: 11))
+                .foregroundStyle(WinampTheme.lcdGlow)
+        }
+        .lcdReadout(corner: 3)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 4)
+    }
+
+    private func formatRemaining(_ seconds: TimeInterval) -> String {
+        let total = Int(seconds)
+        let m = total / 60
+        let s = total % 60
+        return String(format: "%d:%02d", m, s)
+    }
+}


### PR DESCRIPTION
## Linked issue

Closes #16

## Summary

Adds a sleep timer that stops playback after a chosen duration (15/30/45/60 min) or at the natural end of the current track.

## Test plan (PR-specific)

- [ ] Play a track. Tap the clock icon. Choose 15 min. Verify mm:ss LCD countdown appears.
- [ ] Set a 1-min timer. After 1 min music stops and countdown disappears.
- [ ] Mid-countdown tap clock icon → Cancel. Countdown clears, music keeps playing.
- [ ] Choose "End of current track" near end of a song → song finishes naturally, playback stops, queue does not advance.
- [ ] Lock device with timer running. Wait ≥ duration. Unlock — playback paused.
- [ ] Switch tracks via Next/Prev while timer is active — countdown keeps ticking.
- [ ] Repeat all steps in SwiftUI NowPlayingView (no active skin).

## Regression check

- [x] **A. Build + launch** (required)
- [ ] C. Playback
- [ ] D. Shuffle + Repeat

## Screenshots / recordings

Clock icon appears in skinned player top bar (right of skin name, left of ✕) and in the SwiftUI transport row. LCD countdown strip appears below the skin canvas / above Smart Play chip when a timer is set.