### PR TITLE
Skinned player: tap visualizer to cycle spectrum/oscilloscope/off (closes #36)

### DIFF
--- a/HarmonIQ/Views/Skin/SkinnedVisualizer.swift
+++ b/HarmonIQ/Views/Skin/SkinnedVisualizer.swift
@@ -2,14 +2,20 @@ import SwiftUI
 import UIKit
 
 /// A skinned visualizer that draws into the canonical 76×16 visualizer area
-/// using the active skin's VISCOLOR.TXT palette. Follows the authentic Winamp
-/// 3-mode cycle (spectrum → oscilloscope → off) — tap the rect to advance.
+/// using the active skin's VISCOLOR.TXT palette. Reuses VisualizerEngine for
+/// the synthesized state and shares `VisualizerSettings.style` with the
+/// SwiftUI player so cycling stays unified across both UIs — tap the rect to
+/// advance through the 8 styles.
+///
+/// Some `VisualizerStyle` cases (plasma, circle) don't fit the Winamp pixel-grid
+/// + 24-color palette — those fall back to the spectrum bar render so the
+/// skinned player still has *something* sensible to show.
 struct SkinnedVisualizer: View {
     @ObservedObject var engine: VisualizerEngine
     var pixelSize: CGFloat = 2
     @EnvironmentObject var skinManager: SkinManager
     @EnvironmentObject var player: AudioPlayerManager
-    @StateObject private var settings = SkinnedVisualizerSettings.shared
+    @StateObject private var settings = VisualizerSettings.shared
 
     // Cache the resolved SwiftUI Color array so we don't convert UIColor → Color
     // on every frame. Invalidated when the active skin changes.
@@ -49,14 +55,20 @@ struct SkinnedVisualizer: View {
         // Background (palette index 0).
         ctx.fill(Path(CGRect(origin: .zero, size: size)), with: .color(colors[0]))
 
-        switch settings.mode {
-        case .spectrum:
+        switch settings.style {
+        case .spectrum, .plasma, .circle:
+            // plasma/circle don't translate to the 76×16 + palette aesthetic — fall back to bars.
             drawSpectrumBars(ctx: ctx, size: size, colors: colors)
         case .oscilloscope:
             drawOscilloscope(ctx: ctx, size: size, colors: colors)
-        case .off:
-            // Background fill above already painted palette index 0; nothing else to draw.
-            break
+        case .mirror:
+            drawMirrorBars(ctx: ctx, size: size, colors: colors)
+        case .particles:
+            drawParticles(ctx: ctx, size: size, colors: colors)
+        case .fire:
+            drawFire(ctx: ctx, size: size, colors: colors)
+        case .starfield:
+            drawStarfield(ctx: ctx, size: size, colors: colors)
         }
     }
 
@@ -119,7 +131,114 @@ struct SkinnedVisualizer: View {
         }
     }
 
+    private func drawMirrorBars(ctx: GraphicsContext, size: CGSize, colors: [Color]) {
+        let bars = 19
+        let barW = size.width / CGFloat(bars)
+        let bands = engine.bands
+        let mid = size.height / 2
+        // Center reference line in the grid color (palette[1] when present).
+        let refColor = colors.indices.contains(1) ? colors[1].opacity(0.6) : colors[2].opacity(0.4)
+        ctx.fill(Path(CGRect(x: 0, y: mid - 0.5, width: size.width, height: max(1, pixelSize * 0.5))),
+                 with: .color(refColor))
+        for i in 0..<bars {
+            let f = Float(i) / Float(bars - 1)
+            let srcIdx = min(bands.count - 1, Int(f * Float(bands.count - 1) + 0.5))
+            let halfH = CGFloat(bands[srcIdx]) * (size.height * 0.5)
+            guard halfH >= pixelSize else { continue }
+            let x = CGFloat(i) * barW
+            let rowH = pixelSize
+            // Top half — draw upward from the centerline.
+            var y = mid
+            var drawn: CGFloat = 0
+            while drawn < halfH - 0.5 {
+                let frac = drawn / (size.height * 0.5)
+                let levelIdx = 17 - min(15, Int(frac * 15))
+                let color = colors[max(2, min(17, levelIdx))]
+                ctx.fill(Path(CGRect(x: x + 0.5, y: y - rowH, width: barW - 1, height: rowH)),
+                         with: .color(color))
+                ctx.fill(Path(CGRect(x: x + 0.5, y: 2 * mid - y, width: barW - 1, height: rowH)),
+                         with: .color(color.opacity(0.7)))
+                y -= rowH
+                drawn += rowH
+            }
+        }
+    }
+
+    private func drawParticles(ctx: GraphicsContext, size: CGSize, colors: [Color]) {
+        // Floor line in the brightest base color.
+        let floorColor = colors[max(2, min(17, 8))]
+        ctx.fill(Path(CGRect(x: 0, y: size.height - pixelSize, width: size.width, height: pixelSize)),
+                 with: .color(floorColor.opacity(0.5)))
+        // Each particle = one skin pixel block. Color picks from the spectrum palette
+        // ramp by life — fresh = top (hot), old = mid.
+        for p in engine.particles {
+            guard p.life < p.maxLife, p.life >= 0 else { continue }
+            let progress = p.life / p.maxLife
+            let xPx = (CGFloat(p.x) * size.width / pixelSize).rounded() * pixelSize
+            let yPx = (CGFloat(p.y) * size.height / pixelSize).rounded() * pixelSize
+            // Map life [0,1] → palette index [17 (hot) down to 6 (cool)].
+            let idx = 17 - Int(progress * 11)
+            let color = colors[max(2, min(17, idx))].opacity(Double(1 - progress))
+            ctx.fill(Path(CGRect(x: xPx, y: yPx, width: pixelSize, height: pixelSize)),
+                     with: .color(color))
+        }
+    }
+
+    private func drawFire(ctx: GraphicsContext, size: CGSize, colors: [Color]) {
+        // Sample the engine's heat grid (20×14) into the 76×16 skin grid.
+        // The skin's spectrum palette already runs cool→hot bottom-to-top,
+        // so we map heat directly onto palette indices 2…17.
+        let cols = 76
+        let rows = 16
+        let cellW = size.width / CGFloat(cols)
+        let cellH = size.height / CGFloat(rows)
+        let srcCols = VisualizerEngine.fireCols
+        let srcRows = VisualizerEngine.fireRows
+        for r in 0..<rows {
+            // y=0 in the grid is the bottom (hottest) row.
+            let srcR = min(srcRows - 1, Int(Float(r) / Float(rows) * Float(srcRows)))
+            let yPx = size.height - CGFloat(r + 1) * cellH
+            for c in 0..<cols {
+                let srcC = min(srcCols - 1, Int(Float(c) / Float(cols) * Float(srcCols)))
+                let h = engine.fireHeat[srcR * srcCols + srcC]
+                guard h > 0.06 else { continue }
+                // h ∈ [0,1] → palette index [2 (cool) … 17 (hot)].
+                let idx = 2 + Int(h * 15)
+                let color = colors[max(2, min(17, idx))]
+                ctx.fill(Path(CGRect(x: CGFloat(c) * cellW, y: yPx,
+                                     width: cellW + 0.5, height: cellH + 0.5)),
+                         with: .color(color))
+            }
+        }
+    }
+
+    private func drawStarfield(ctx: GraphicsContext, size: CGSize, colors: [Color]) {
+        // White-ish "star" color: prefer palette[18] (oscilloscope), fall back to palette[17] (peak).
+        let starColor = colors.indices.contains(18) ? colors[18] : colors[17]
+        let cx = size.width / 2
+        let cy = size.height / 2
+        let scale = min(size.width, size.height) * 0.8
+        for s in engine.stars {
+            let sxRaw = cx + CGFloat(s.x / s.z) * scale * 0.5
+            let syRaw = cy + CGFloat(s.y / s.z) * scale * 0.5
+            guard sxRaw >= 0, sxRaw < size.width, syRaw >= 0, syRaw < size.height else { continue }
+            // Snap to the skin-pixel grid.
+            let xPx = (sxRaw / pixelSize).floor() * pixelSize
+            let yPx = (syRaw / pixelSize).floor() * pixelSize
+            let depth = max(0.05, min(1.0, s.z))
+            let alpha = 1.0 - Double(depth) * 0.8
+            ctx.fill(Path(CGRect(x: xPx, y: yPx, width: pixelSize, height: pixelSize)),
+                     with: .color(starColor.opacity(alpha)))
+        }
+    }
+
     private func defaultPalette() -> [UIColor] {
         (0..<24).map { i in UIColor(red: 0, green: CGFloat(40 + i * 9) / 255.0, blue: 0, alpha: 1) }
     }
+}
+
+// MARK: - small helpers
+
+private extension CGFloat {
+    func floor() -> CGFloat { rounded(.down) }
 }

--- a/HarmonIQ/Views/Skin/SkinnedVisualizer.swift
+++ b/HarmonIQ/Views/Skin/SkinnedVisualizer.swift
@@ -2,19 +2,14 @@ import SwiftUI
 import UIKit
 
 /// A skinned visualizer that draws into the canonical 76×16 visualizer area
-/// using the active skin's VISCOLOR.TXT palette. Reuses VisualizerEngine for
-/// the synthesized state so this stays a drop-in render layer on top of the
-/// existing engine, and switches between styles based on VisualizerSettings.
-///
-/// Some VisualizerStyle cases (plasma, circle) don't fit the Winamp pixel-grid
-/// + 24-color palette — those fall back to the spectrum bar render so the
-/// skinned player still has *something* sensible to show.
+/// using the active skin's VISCOLOR.TXT palette. Follows the authentic Winamp
+/// 3-mode cycle (spectrum → oscilloscope → off) — tap the rect to advance.
 struct SkinnedVisualizer: View {
     @ObservedObject var engine: VisualizerEngine
     var pixelSize: CGFloat = 2
     @EnvironmentObject var skinManager: SkinManager
     @EnvironmentObject var player: AudioPlayerManager
-    @StateObject private var settings = VisualizerSettings.shared
+    @StateObject private var settings = SkinnedVisualizerSettings.shared
 
     // Cache the resolved SwiftUI Color array so we don't convert UIColor → Color
     // on every frame. Invalidated when the active skin changes.
@@ -29,6 +24,8 @@ struct SkinnedVisualizer: View {
             }
         }
         .frame(width: 76 * pixelSize, height: 16 * pixelSize)
+        .contentShape(Rectangle())
+        .onTapGesture { settings.cycle() }
     }
 
     private func resolvedColors() -> [Color] {
@@ -52,20 +49,14 @@ struct SkinnedVisualizer: View {
         // Background (palette index 0).
         ctx.fill(Path(CGRect(origin: .zero, size: size)), with: .color(colors[0]))
 
-        switch settings.style {
-        case .spectrum, .plasma, .circle:
-            // plasma/circle don't translate to the 76×16 + palette aesthetic — fall back to bars.
+        switch settings.mode {
+        case .spectrum:
             drawSpectrumBars(ctx: ctx, size: size, colors: colors)
         case .oscilloscope:
             drawOscilloscope(ctx: ctx, size: size, colors: colors)
-        case .mirror:
-            drawMirrorBars(ctx: ctx, size: size, colors: colors)
-        case .particles:
-            drawParticles(ctx: ctx, size: size, colors: colors)
-        case .fire:
-            drawFire(ctx: ctx, size: size, colors: colors)
-        case .starfield:
-            drawStarfield(ctx: ctx, size: size, colors: colors)
+        case .off:
+            // Background fill above already painted palette index 0; nothing else to draw.
+            break
         }
     }
 
@@ -128,114 +119,7 @@ struct SkinnedVisualizer: View {
         }
     }
 
-    private func drawMirrorBars(ctx: GraphicsContext, size: CGSize, colors: [Color]) {
-        let bars = 19
-        let barW = size.width / CGFloat(bars)
-        let bands = engine.bands
-        let mid = size.height / 2
-        // Center reference line in the grid color (palette[1] when present).
-        let refColor = colors.indices.contains(1) ? colors[1].opacity(0.6) : colors[2].opacity(0.4)
-        ctx.fill(Path(CGRect(x: 0, y: mid - 0.5, width: size.width, height: max(1, pixelSize * 0.5))),
-                 with: .color(refColor))
-        for i in 0..<bars {
-            let f = Float(i) / Float(bars - 1)
-            let srcIdx = min(bands.count - 1, Int(f * Float(bands.count - 1) + 0.5))
-            let halfH = CGFloat(bands[srcIdx]) * (size.height * 0.5)
-            guard halfH >= pixelSize else { continue }
-            let x = CGFloat(i) * barW
-            let rowH = pixelSize
-            // Top half — draw upward from the centerline.
-            var y = mid
-            var drawn: CGFloat = 0
-            while drawn < halfH - 0.5 {
-                let frac = drawn / (size.height * 0.5)
-                let levelIdx = 17 - min(15, Int(frac * 15))
-                let color = colors[max(2, min(17, levelIdx))]
-                ctx.fill(Path(CGRect(x: x + 0.5, y: y - rowH, width: barW - 1, height: rowH)),
-                         with: .color(color))
-                ctx.fill(Path(CGRect(x: x + 0.5, y: 2 * mid - y, width: barW - 1, height: rowH)),
-                         with: .color(color.opacity(0.7)))
-                y -= rowH
-                drawn += rowH
-            }
-        }
-    }
-
-    private func drawParticles(ctx: GraphicsContext, size: CGSize, colors: [Color]) {
-        // Floor line in the brightest base color.
-        let floorColor = colors[max(2, min(17, 8))]
-        ctx.fill(Path(CGRect(x: 0, y: size.height - pixelSize, width: size.width, height: pixelSize)),
-                 with: .color(floorColor.opacity(0.5)))
-        // Each particle = one skin pixel block. Color picks from the spectrum palette
-        // ramp by life — fresh = top (hot), old = mid.
-        for p in engine.particles {
-            guard p.life < p.maxLife, p.life >= 0 else { continue }
-            let progress = p.life / p.maxLife
-            let xPx = (CGFloat(p.x) * size.width / pixelSize).rounded() * pixelSize
-            let yPx = (CGFloat(p.y) * size.height / pixelSize).rounded() * pixelSize
-            // Map life [0,1] → palette index [17 (hot) down to 6 (cool)].
-            let idx = 17 - Int(progress * 11)
-            let color = colors[max(2, min(17, idx))].opacity(Double(1 - progress))
-            ctx.fill(Path(CGRect(x: xPx, y: yPx, width: pixelSize, height: pixelSize)),
-                     with: .color(color))
-        }
-    }
-
-    private func drawFire(ctx: GraphicsContext, size: CGSize, colors: [Color]) {
-        // Sample the engine's heat grid (20×14) into the 76×16 skin grid.
-        // The skin's spectrum palette already runs cool→hot bottom-to-top,
-        // so we map heat directly onto palette indices 2…17.
-        let cols = 76
-        let rows = 16
-        let cellW = size.width / CGFloat(cols)
-        let cellH = size.height / CGFloat(rows)
-        let srcCols = VisualizerEngine.fireCols
-        let srcRows = VisualizerEngine.fireRows
-        for r in 0..<rows {
-            // y=0 in the grid is the bottom (hottest) row.
-            let srcR = min(srcRows - 1, Int(Float(r) / Float(rows) * Float(srcRows)))
-            let yPx = size.height - CGFloat(r + 1) * cellH
-            for c in 0..<cols {
-                let srcC = min(srcCols - 1, Int(Float(c) / Float(cols) * Float(srcCols)))
-                let h = engine.fireHeat[srcR * srcCols + srcC]
-                guard h > 0.06 else { continue }
-                // h ∈ [0,1] → palette index [2 (cool) … 17 (hot)].
-                let idx = 2 + Int(h * 15)
-                let color = colors[max(2, min(17, idx))]
-                ctx.fill(Path(CGRect(x: CGFloat(c) * cellW, y: yPx,
-                                     width: cellW + 0.5, height: cellH + 0.5)),
-                         with: .color(color))
-            }
-        }
-    }
-
-    private func drawStarfield(ctx: GraphicsContext, size: CGSize, colors: [Color]) {
-        // White-ish "star" color: prefer palette[18] (oscilloscope), fall back to palette[17] (peak).
-        let starColor = colors.indices.contains(18) ? colors[18] : colors[17]
-        let cx = size.width / 2
-        let cy = size.height / 2
-        let scale = min(size.width, size.height) * 0.8
-        for s in engine.stars {
-            let sxRaw = cx + CGFloat(s.x / s.z) * scale * 0.5
-            let syRaw = cy + CGFloat(s.y / s.z) * scale * 0.5
-            guard sxRaw >= 0, sxRaw < size.width, syRaw >= 0, syRaw < size.height else { continue }
-            // Snap to the skin-pixel grid.
-            let xPx = (sxRaw / pixelSize).floor() * pixelSize
-            let yPx = (syRaw / pixelSize).floor() * pixelSize
-            let depth = max(0.05, min(1.0, s.z))
-            let alpha = 1.0 - Double(depth) * 0.8
-            ctx.fill(Path(CGRect(x: xPx, y: yPx, width: pixelSize, height: pixelSize)),
-                     with: .color(starColor.opacity(alpha)))
-        }
-    }
-
     private func defaultPalette() -> [UIColor] {
         (0..<24).map { i in UIColor(red: 0, green: CGFloat(40 + i * 9) / 255.0, blue: 0, alpha: 1) }
     }
-}
-
-// MARK: - small helpers
-
-private extension CGFloat {
-    func floor() -> CGFloat { rounded(.down) }
 }

--- a/HarmonIQ/Views/Visualizers.swift
+++ b/HarmonIQ/Views/Visualizers.swift
@@ -63,6 +63,39 @@ final class VisualizerSettings: ObservableObject {
     }
 }
 
+/// Classic Winamp visualizer modes for the skinned player. Tapping the
+/// 76×16 visualizer rect cycles through these in order.
+enum SkinnedVisualizerMode: String, CaseIterable {
+    case spectrum
+    case oscilloscope
+    case off
+}
+
+/// Persisted skinned-player visualizer mode. Lives separately from
+/// `VisualizerSettings` because the skinned player follows the authentic
+/// Winamp 3-mode cycle, while the SwiftUI player has the richer 8-style set.
+@MainActor
+final class SkinnedVisualizerSettings: ObservableObject {
+    static let shared = SkinnedVisualizerSettings()
+
+    private let key = "harmoniq.skinnedVisualizerMode"
+
+    @Published var mode: SkinnedVisualizerMode {
+        didSet { UserDefaults.standard.set(mode.rawValue, forKey: key) }
+    }
+
+    init() {
+        let raw = UserDefaults.standard.string(forKey: key) ?? ""
+        self.mode = SkinnedVisualizerMode(rawValue: raw) ?? .spectrum
+    }
+
+    func cycle() {
+        let all = SkinnedVisualizerMode.allCases
+        let i = all.firstIndex(of: mode) ?? 0
+        mode = all[(i + 1) % all.count]
+    }
+}
+
 /// Container that sits in NowPlayingView. Uses a TimelineView so we redraw at ~30Hz
 /// regardless of @Published throttling, and reads the latest level from the player.
 struct VisualizerView: View {

--- a/HarmonIQ/Views/Visualizers.swift
+++ b/HarmonIQ/Views/Visualizers.swift
@@ -63,39 +63,6 @@ final class VisualizerSettings: ObservableObject {
     }
 }
 
-/// Classic Winamp visualizer modes for the skinned player. Tapping the
-/// 76×16 visualizer rect cycles through these in order.
-enum SkinnedVisualizerMode: String, CaseIterable {
-    case spectrum
-    case oscilloscope
-    case off
-}
-
-/// Persisted skinned-player visualizer mode. Lives separately from
-/// `VisualizerSettings` because the skinned player follows the authentic
-/// Winamp 3-mode cycle, while the SwiftUI player has the richer 8-style set.
-@MainActor
-final class SkinnedVisualizerSettings: ObservableObject {
-    static let shared = SkinnedVisualizerSettings()
-
-    private let key = "harmoniq.skinnedVisualizerMode"
-
-    @Published var mode: SkinnedVisualizerMode {
-        didSet { UserDefaults.standard.set(mode.rawValue, forKey: key) }
-    }
-
-    init() {
-        let raw = UserDefaults.standard.string(forKey: key) ?? ""
-        self.mode = SkinnedVisualizerMode(rawValue: raw) ?? .spectrum
-    }
-
-    func cycle() {
-        let all = SkinnedVisualizerMode.allCases
-        let i = all.firstIndex(of: mode) ?? 0
-        mode = all[(i + 1) % all.count]
-    }
-}
-
 /// Container that sits in NowPlayingView. Uses a TimelineView so we redraw at ~30Hz
 /// regardless of @Published throttling, and reads the latest level from the player.
 struct VisualizerView: View {

--- a/TESTING.md
+++ b/TESTING.md
@@ -67,7 +67,7 @@ If a section is irrelevant to your PR (e.g. you only touched skin loading), stil
 - [ ] Tapping a skin row updates the now-playing sheet on next open.
 - [ ] In the skinned player: tap-to-cycle skin button advances to the next skin and shows its name.
 - [ ] Long-press the cycle button → scrollable skin picker sheet.
-- [ ] In the skinned player: tap the visualizer rect (76×16 area) cycles spectrum → oscilloscope → off → spectrum, persists across sheet close and app relaunch.
+- [ ] In the skinned player: tap the visualizer rect (76×16 area) cycles through all 8 visualizer styles (Spectrum, Oscilloscope, Plasma, Mirror, Radial Pulse, Particles, Fire, Starfield); plasma/circle fall back to the spectrum bar render in the 76×16 grid. Style is shared with the SwiftUI player and persists across sheet close and app relaunch.
 - [ ] Import a `.wsz` from Files → it appears in the list and loads without crashing.
 - [ ] **None** option (top of the list) falls back to the SwiftUI player on next sheet open.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -67,6 +67,7 @@ If a section is irrelevant to your PR (e.g. you only touched skin loading), stil
 - [ ] Tapping a skin row updates the now-playing sheet on next open.
 - [ ] In the skinned player: tap-to-cycle skin button advances to the next skin and shows its name.
 - [ ] Long-press the cycle button → scrollable skin picker sheet.
+- [ ] In the skinned player: tap the visualizer rect (76×16 area) cycles spectrum → oscilloscope → off → spectrum, persists across sheet close and app relaunch.
 - [ ] Import a `.wsz` from Files → it appears in the list and loads without crashing.
 - [ ] **None** option (top of the list) falls back to the SwiftUI player on next sheet open.
 


### PR DESCRIPTION
## Summary
- New `SkinnedVisualizerSettings` singleton (UserDefaults key `harmoniq.skinnedVisualizerMode`) drives a 3-mode cycle in the Winamp-skinned player: **spectrum → oscilloscope → off**.
- `SkinnedVisualizer` gets a single-tap gesture on the 76×16 rect; choice persists across sheet close and app relaunch.
- Skinned renderer collapses back from the 8-style switch (mirror/particles/fire/starfield) to the classic 3 modes — the SwiftUI player retains all 8 styles via the existing `VisualizerSettings`.

Closes #36.

## Test plan
- [ ] Build on iPhone 17 sim — passes (`xcodebuild build`).
- [ ] Open now-playing sheet with a skinned player active → tap visualizer rect → spectrum bars switch to oscilloscope line.
- [ ] Tap again → rect goes blank (palette index 0 background).
- [ ] Tap again → spectrum bars return.
- [ ] Close sheet, reopen → mode persists.
- [ ] Force-quit + relaunch → mode persists.
- [ ] Switch active skin → reopened sheet still respects last mode; oscilloscope uses new skin's palette index 18.
- [ ] Non-skinned (SwiftUI) player: long-press / double-tap still cycles all 8 `VisualizerStyle` cases — unchanged.
- [ ] `TESTING.md` section A + new section E item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)