### PR TITLE
Favorites: heart toggle on player + Favorites playlist (closes #33)

### DIFF
--- a/HarmonIQ/Models/Playlist.swift
+++ b/HarmonIQ/Models/Playlist.swift
@@ -9,19 +9,24 @@ struct Playlist: Identifiable, Hashable {
     /// Which drive owns this playlist. In-memory only — bound when the playlist
     /// is loaded from the drive (or when it is created), never serialized to disk.
     var rootBookmarkID: UUID
+    /// True when this is the drive's system "Favorites" playlist. Each drive has
+    /// at most one. Persisted to the drive (so all devices see the same set).
+    var isFavorites: Bool
 
     init(id: UUID = UUID(),
          name: String,
          trackIDs: [String] = [],
          createdAt: Date = Date(),
          updatedAt: Date = Date(),
-         rootBookmarkID: UUID) {
+         rootBookmarkID: UUID,
+         isFavorites: Bool = false) {
         self.id = id
         self.name = name
         self.trackIDs = trackIDs
         self.createdAt = createdAt
         self.updatedAt = updatedAt
         self.rootBookmarkID = rootBookmarkID
+        self.isFavorites = isFavorites
     }
 }
 

--- a/HarmonIQ/Persistence/DriveLibraryStore.swift
+++ b/HarmonIQ/Persistence/DriveLibraryStore.swift
@@ -53,6 +53,10 @@ enum DriveLibraryStore {
         var trackIDs: [String]
         var createdAt: Date
         var updatedAt: Date
+        /// Optional kind tag. `"favorites"` marks the drive's system Favorites
+        /// playlist; nil/missing means a normal user playlist. Optional so
+        /// existing playlists.json files (no `kind` field) decode unchanged.
+        var kind: String?
     }
 
     // MARK: - Paths
@@ -162,6 +166,8 @@ enum DriveLibraryStore {
         )
     }
 
+    static let favoritesKind = "favorites"
+
     static func toPlaylist(_ dp: DrivePlaylist, rootBookmarkID: UUID) -> Playlist {
         Playlist(
             id: dp.id,
@@ -169,7 +175,8 @@ enum DriveLibraryStore {
             trackIDs: dp.trackIDs,
             createdAt: dp.createdAt,
             updatedAt: dp.updatedAt,
-            rootBookmarkID: rootBookmarkID
+            rootBookmarkID: rootBookmarkID,
+            isFavorites: dp.kind == favoritesKind
         )
     }
 
@@ -179,7 +186,8 @@ enum DriveLibraryStore {
             name: p.name,
             trackIDs: p.trackIDs,
             createdAt: p.createdAt,
-            updatedAt: p.updatedAt
+            updatedAt: p.updatedAt,
+            kind: p.isFavorites ? favoritesKind : nil
         )
     }
 

--- a/HarmonIQ/Persistence/LibraryStore.swift
+++ b/HarmonIQ/Persistence/LibraryStore.swift
@@ -292,6 +292,49 @@ final class LibraryStore: ObservableObject {
         return playlist.trackIDs.compactMap { map[$0] }
     }
 
+    // MARK: - Favorites
+
+    /// Per-drive system Favorites playlist, if one exists for the given drive.
+    func favoritesPlaylist(forRoot rootID: UUID) -> Playlist? {
+        playlists.first { $0.rootBookmarkID == rootID && $0.isFavorites }
+    }
+
+    /// All Favorites playlists across mounted drives, sorted by drive display name.
+    var favoritesPlaylists: [Playlist] {
+        let favs = playlists.filter { $0.isFavorites }
+        let nameByRoot: [UUID: String] = Dictionary(uniqueKeysWithValues: roots.map { ($0.id, $0.displayName) })
+        return favs.sorted { (nameByRoot[$0.rootBookmarkID] ?? "") .localizedStandardCompare(nameByRoot[$1.rootBookmarkID] ?? "") == .orderedAscending }
+    }
+
+    /// True if `track` belongs to its drive's Favorites playlist.
+    func isFavorite(_ track: Track) -> Bool {
+        guard let fav = favoritesPlaylist(forRoot: track.rootBookmarkID) else { return false }
+        return fav.trackIDs.contains(track.stableID)
+    }
+
+    /// Toggles favorite state for a track. Auto-creates the drive's Favorites
+    /// playlist on first toggle. Returns the new state (true = now favorited).
+    /// No-op (returns false) if the track's drive isn't currently mounted.
+    @discardableResult
+    func toggleFavorite(_ track: Track) -> Bool {
+        let rootID = track.rootBookmarkID
+        guard roots.contains(where: { $0.id == rootID }) else { return false }
+        if let fav = favoritesPlaylist(forRoot: rootID) {
+            if fav.trackIDs.contains(track.stableID) {
+                removeTrack(track.stableID, from: fav)
+                return false
+            } else {
+                addTracks([track.stableID], to: fav)
+                return true
+            }
+        } else {
+            let new = Playlist(name: "Favorites", trackIDs: [track.stableID], rootBookmarkID: rootID, isFavorites: true)
+            playlists.append(new)
+            writePlaylistsToDrive(rootID: rootID)
+            return true
+        }
+    }
+
     // MARK: - Aggregations
 
     var allArtists: [String] {

--- a/HarmonIQ/Views/NowPlayingView.swift
+++ b/HarmonIQ/Views/NowPlayingView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct NowPlayingView: View {
     @EnvironmentObject var player: AudioPlayerManager
     @EnvironmentObject var skinManager: SkinManager
+    @EnvironmentObject var library: LibraryStore
     @Environment(\.dismiss) private var dismiss
     @State private var seekingValue: Double?
     @State private var showSkinPicker = false
@@ -99,6 +100,9 @@ struct NowPlayingView: View {
                             .foregroundStyle(WinampTheme.lcdGlow)
                     }
                     Spacer()
+                    FavoriteButton()
+                        .environmentObject(player)
+                        .environmentObject(library)
                 }
                 .bevelPanel()
                 .padding(.horizontal, 16)
@@ -207,6 +211,30 @@ struct NowPlayingView: View {
     private func formatRate(_ track: Track?) -> String {
         guard let format = track?.fileFormat else { return "" }
         return format.uppercased()
+    }
+}
+
+/// Heart toggle for the currently playing track. Reflects favorite state via
+/// `library.isFavorite(_:)` and writes through `library.toggleFavorite(_:)`,
+/// which auto-creates the drive's Favorites playlist on first toggle.
+struct FavoriteButton: View {
+    @EnvironmentObject var player: AudioPlayerManager
+    @EnvironmentObject var library: LibraryStore
+
+    var body: some View {
+        let track = player.currentTrack
+        let isFav = track.map { library.isFavorite($0) } ?? false
+        Button {
+            guard let t = track else { return }
+            _ = library.toggleFavorite(t)
+        } label: {
+            Image(systemName: isFav ? "heart.fill" : "heart")
+                .font(.title2)
+                .foregroundStyle(isFav ? WinampTheme.lcdGlow : WinampTheme.lcdDim)
+        }
+        .chromeButton(pressed: isFav)
+        .disabled(track == nil)
+        .accessibilityLabel(isFav ? "Unfavorite track" : "Favorite track")
     }
 }
 

--- a/HarmonIQ/Views/PlaylistsView.swift
+++ b/HarmonIQ/Views/PlaylistsView.swift
@@ -6,6 +6,12 @@ struct PlaylistsView: View {
     @State private var newName = ""
     @State private var showNoDriveAlert = false
 
+    private var favorites: [Playlist] { library.favoritesPlaylists }
+    private var userPlaylists: [Playlist] { library.playlists.filter { !$0.isFavorites } }
+    private var driveName: [UUID: String] {
+        Dictionary(uniqueKeysWithValues: library.roots.map { ($0.id, $0.displayName) })
+    }
+
     var body: some View {
         Group {
             if library.playlists.isEmpty {
@@ -16,24 +22,56 @@ struct PlaylistsView: View {
                                systemImage: "music.note.list")
             } else {
                 List {
-                    ForEach(library.playlists) { playlist in
-                        NavigationLink {
-                            PlaylistDetailView(playlist: playlist)
-                        } label: {
-                            HStack(spacing: 12) {
-                                Image(systemName: "music.note.list")
-                                    .font(.title3)
-                                    .foregroundStyle(.tint)
-                                    .frame(width: 36, height: 36)
-                                    .background(.tint.opacity(0.15), in: RoundedRectangle(cornerRadius: 8))
-                                VStack(alignment: .leading, spacing: 2) {
-                                    Text(playlist.name)
-                                    Text("\(playlist.trackIDs.count) tracks").font(.caption).foregroundStyle(.secondary)
+                    if !favorites.isEmpty {
+                        Section {
+                            ForEach(favorites) { playlist in
+                                NavigationLink {
+                                    PlaylistDetailView(playlist: playlist)
+                                } label: {
+                                    HStack(spacing: 12) {
+                                        Image(systemName: "heart.fill")
+                                            .font(.title3)
+                                            .foregroundStyle(.pink)
+                                            .frame(width: 36, height: 36)
+                                            .background(Color.pink.opacity(0.15), in: RoundedRectangle(cornerRadius: 8))
+                                        VStack(alignment: .leading, spacing: 2) {
+                                            // Show drive name only when there's more than one drive,
+                                            // so single-drive setups stay clean.
+                                            if library.roots.count > 1 {
+                                                Text("Favorites · \(driveName[playlist.rootBookmarkID] ?? "")")
+                                            } else {
+                                                Text("Favorites")
+                                            }
+                                            Text("\(playlist.trackIDs.count) tracks").font(.caption).foregroundStyle(.secondary)
+                                        }
+                                    }
                                 }
                             }
                         }
                     }
-                    .onDelete(perform: delete)
+
+                    if !userPlaylists.isEmpty {
+                        Section {
+                            ForEach(userPlaylists) { playlist in
+                                NavigationLink {
+                                    PlaylistDetailView(playlist: playlist)
+                                } label: {
+                                    HStack(spacing: 12) {
+                                        Image(systemName: "music.note.list")
+                                            .font(.title3)
+                                            .foregroundStyle(.tint)
+                                            .frame(width: 36, height: 36)
+                                            .background(.tint.opacity(0.15), in: RoundedRectangle(cornerRadius: 8))
+                                        VStack(alignment: .leading, spacing: 2) {
+                                            Text(playlist.name)
+                                            Text("\(playlist.trackIDs.count) tracks").font(.caption).foregroundStyle(.secondary)
+                                        }
+                                    }
+                                }
+                            }
+                            .onDelete(perform: deleteUserPlaylist)
+                        }
+                    }
                 }
             }
         }
@@ -68,10 +106,10 @@ struct PlaylistsView: View {
         }
     }
 
-    private func delete(at offsets: IndexSet) {
-        for idx in offsets {
-            let playlist = library.playlists[idx]
-            library.deletePlaylist(playlist)
+    private func deleteUserPlaylist(at offsets: IndexSet) {
+        let snapshot = userPlaylists
+        for idx in offsets where snapshot.indices.contains(idx) {
+            library.deletePlaylist(snapshot[idx])
         }
     }
 }
@@ -132,21 +170,25 @@ struct PlaylistDetailView: View {
         .navigationTitle(playlist.name)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
-                Menu {
-                    Button {
-                        newName = playlist.name
-                        renameSheet = true
+            // Favorites is auto-managed via the heart button on the player —
+            // hide the rename/delete menu to avoid orphaning state.
+            if !playlist.isFavorites {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Menu {
+                        Button {
+                            newName = playlist.name
+                            renameSheet = true
+                        } label: {
+                            Label("Rename", systemImage: "pencil")
+                        }
+                        Button(role: .destructive) {
+                            library.deletePlaylist(playlist)
+                        } label: {
+                            Label("Delete Playlist", systemImage: "trash")
+                        }
                     } label: {
-                        Label("Rename", systemImage: "pencil")
+                        Image(systemName: "ellipsis.circle")
                     }
-                    Button(role: .destructive) {
-                        library.deletePlaylist(playlist)
-                    } label: {
-                        Label("Delete Playlist", systemImage: "trash")
-                    }
-                } label: {
-                    Image(systemName: "ellipsis.circle")
                 }
             }
         }

--- a/HarmonIQ/Views/Skin/SkinnedMainView.swift
+++ b/HarmonIQ/Views/Skin/SkinnedMainView.swift
@@ -7,6 +7,7 @@ import UIKit
 struct SkinnedMainView: View {
     @EnvironmentObject var skinManager: SkinManager
     @EnvironmentObject var player: AudioPlayerManager
+    @EnvironmentObject var library: LibraryStore
     @StateObject private var visEngine = VisualizerEngine()
     @Environment(\.dismiss) private var dismiss
 
@@ -56,6 +57,10 @@ struct SkinnedMainView: View {
                     )
 
                     Spacer()
+
+                    SkinnedFavoriteButton()
+                        .environmentObject(player)
+                        .environmentObject(library)
 
                     SleepTimerButton()
                         .environmentObject(player)
@@ -458,5 +463,29 @@ struct SkinPickerSheet: View {
                 }
             }
         }
+    }
+}
+
+/// Favorite toggle styled to match the skinned player's chrome bar — sits next
+/// to the sleep timer / close button. Mirrors `FavoriteButton` semantics but
+/// uses the chrome bar's white-on-black palette instead of LCD green.
+struct SkinnedFavoriteButton: View {
+    @EnvironmentObject var player: AudioPlayerManager
+    @EnvironmentObject var library: LibraryStore
+
+    var body: some View {
+        let track = player.currentTrack
+        let isFav = track.map { library.isFavorite($0) } ?? false
+        Button {
+            guard let t = track else { return }
+            _ = library.toggleFavorite(t)
+        } label: {
+            Image(systemName: isFav ? "heart.fill" : "heart")
+                .font(.title2)
+                .foregroundStyle(isFav ? Color.pink.opacity(0.95) : .white.opacity(0.85),
+                                 .black.opacity(0.6))
+        }
+        .disabled(track == nil)
+        .accessibilityLabel(isFav ? "Unfavorite track" : "Favorite track")
     }
 }

--- a/TESTING.md
+++ b/TESTING.md
@@ -80,6 +80,10 @@ If a section is irrelevant to your PR (e.g. you only touched skin loading), stil
 - [ ] Remove a track via swipe.
 - [ ] Delete a playlist via toolbar menu.
 - [ ] Cross-device persistence: confirm `<DriveRoot>/HarmonIQ/playlists.json` is written for writable drives. (For the simulator-seeded folder, this is `<simulator-app-container>/Documents/FakeDrive/HarmonIQ/playlists.json`.)
+- [ ] Favorite a track in the player (heart turns filled); the Playlists tab shows a pinned **Favorites** entry above the regular playlists. Tap it → favorited track is listed.
+- [ ] Unfavorite from the player → heart unfills, count in Favorites decrements; if it was the last track the Favorites row remains (auto-managed) but shows `0 tracks`.
+- [ ] Quit + relaunch → favorite state survives; the on-drive `playlists.json` includes `"kind": "favorites"` for the system playlist.
+- [ ] With 2+ drives mounted, favorite tracks from each → two Favorites rows appear, each labelled with its drive name.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds an auto-managed system **Favorites** playlist per drive, stored on the drive (Option A from the issue) so favorites travel between devices.
- Persistence: `DrivePlaylist` DTO gains an optional `kind` field (\`"favorites"\` for the system playlist; unset for user playlists). Existing `playlists.json` files decode unchanged.
- `LibraryStore.toggleFavorite(_:)` is the single entry point — auto-creates the drive's Favorites playlist on first toggle, toggles membership otherwise; respects read-only roots via the existing sandbox shadow store.
- UI:
  - SwiftUI Now Playing screen: heart in the artwork chip (\`chromeButton\`-styled).
  - Skinned (Winamp) main player: heart in the top chrome bar next to the sleep timer / close button.
  - PlaylistsView: pinned **Favorites** section above the user playlists; drive name shown only when there are 2+ drives. Favorites rows skip the rename/delete menu since they're auto-managed.

Closes #33.

## Test plan
- [x] Build green on iPhone 17 simulator (\`xcodebuild build\`).
- [ ] Now Playing (SwiftUI): heart unfilled by default; tap → fills, plays haptic feedback via chromeButton style.
- [ ] Tap heart again → unfills, count drops in Favorites row.
- [ ] Skinned player: heart appears in top chrome bar; toggles same state as the SwiftUI heart.
- [ ] Playlists tab: pinned **Favorites** entry appears above user playlists once first track is favorited; counter increments correctly.
- [ ] Favorites row → opens normal PlaylistDetailView; rename/delete menu is hidden.
- [ ] Force-quit + relaunch: favorite state survives; \`<DriveRoot>/HarmonIQ/playlists.json\` includes \`"kind": "favorites"\`.
- [ ] Two drives mounted → favorite tracks from each → two Favorites rows, each labelled by drive name.
- [ ] Read-only root: favoriting a track from a read-only drive persists via SandboxRootStore (no crash).
- [ ] Existing \`playlists.json\` (no \`kind\` field) decodes without errors after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)