### PR TITLE
Skins: add CREDITS + fetch-extra-skins helper (refs #24)

### DIFF
--- a/HarmonIQ/Resources/Skins/CREDITS.txt
+++ b/HarmonIQ/Resources/Skins/CREDITS.txt
@@ -1,0 +1,37 @@
+Bundled Winamp skins
+====================
+
+The .wsz files in this folder are classic third-party Winamp 2.x skins
+sourced from the Internet Archive's Webamp Skin Museum (skins.webamp.org).
+Each skin is the work of its original author and is included here under
+the licensing terms it was distributed with — most Winamp-era skins were
+released as freeware for non-commercial redistribution.
+
+Currently bundled:
+
+  Base-2.91.wsz             — Winamp 2.91 default ("Base") skin
+  Bento-Classified.wsz      — Bento Classified
+  Crystal-Display.wsz       — Crystal Display
+  Glass-Factory.wsz         — Glass Factory
+  Green-Dimension-V2.wsz    — Green Dimension V2
+  Internet-Archive.wsz      — Internet Archive themed skin
+  Luna-Steel.wsz            — Luna Steel
+  MacOSXAqua1-5.wsz         — Mac OS X Aqua 1.5
+  TopazAmp1-2.wsz           — TopazAmp 1.2
+
+Adding more skins
+-----------------
+
+The script `scripts/fetch-extra-skins.sh` (in the repo root) downloads
+.wsz files from a list of URLs you provide on stdin, drops them into
+this folder, and reminds you to re-run `xcodegen generate`. Use it to
+add more skins from skins.webamp.org or other archives. Verify each
+skin's license terms before redistributing.
+
+Removing a skin
+---------------
+
+Just delete its .wsz file from this folder. The skin picker enumerates
+the folder at runtime — no project regeneration is required for
+removals. (Adds DO require regen because XcodeGen treats this folder
+as a build-time resource bundle.)

--- a/scripts/fetch-extra-skins.sh
+++ b/scripts/fetch-extra-skins.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# fetch-extra-skins.sh — download .wsz Winamp skins into the bundled
+# Resources/Skins/ folder.
+#
+# Reads a newline-separated list of URLs from stdin. Each URL must point at
+# a .wsz file. Files are saved by their last path component, deduped by
+# filename, and the user is reminded to regenerate the Xcode project so
+# the new skin gets bundled into the app.
+#
+# Usage:
+#   ./scripts/fetch-extra-skins.sh <<EOF
+#   https://example.com/skin/CoolSkin.wsz
+#   https://example.com/skin/Another.wsz
+#   EOF
+#
+# Or feed a file:
+#   ./scripts/fetch-extra-skins.sh < urls.txt
+#
+# Verify each source's license before redistributing.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SKIN_DIR="$REPO_ROOT/HarmonIQ/Resources/Skins"
+
+if [ ! -d "$SKIN_DIR" ]; then
+  echo "error: skin directory not found at $SKIN_DIR" >&2
+  exit 1
+fi
+
+added=0
+skipped=0
+
+while IFS= read -r url || [ -n "$url" ]; do
+  url="$(echo "$url" | tr -d '\r' | xargs)"
+  case "$url" in
+    ""|\#*) continue ;;
+  esac
+  filename="$(basename "${url%%\?*}")"
+  case "$filename" in
+    *.wsz) ;;
+    *)
+      echo "skip: $url (not a .wsz)" >&2
+      skipped=$((skipped+1))
+      continue
+      ;;
+  esac
+  out="$SKIN_DIR/$filename"
+  if [ -e "$out" ]; then
+    echo "skip: $filename (already exists)"
+    skipped=$((skipped+1))
+    continue
+  fi
+  echo "fetch: $url"
+  if curl -fL --retry 2 -o "$out" "$url"; then
+    added=$((added+1))
+  else
+    echo "  failed: $url" >&2
+    rm -f "$out"
+  fi
+done
+
+echo
+echo "added=$added skipped=$skipped"
+if [ "$added" -gt 0 ]; then
+  echo
+  echo "next: re-run \`xcodegen generate\` (and rebuild) so the new skins"
+  echo "are picked up by the app bundle."
+fi


### PR DESCRIPTION
## Summary
Issue #24 wants 5+ more `.wsz` files bundled. Downloading them autonomously needs network egress to skin archives that aren't reachable from this environment, so this PR ships the supporting scaffolding only:

- `HarmonIQ/Resources/Skins/CREDITS.txt` — attribution + license posture for the 9 currently bundled skins, plus an instruction on how to add more.
- `scripts/fetch-extra-skins.sh` — reads `.wsz` URLs from stdin, dedupes against existing files, downloads into `Resources/Skins/`, and prints the `xcodegen generate` reminder.

To finish the issue, the user (or a follow-up agent with web access) just needs to:

```
./scripts/fetch-extra-skins.sh <<EOF
https://example.com/skin/CyberpunkNeon.wsz
https://example.com/skin/VHSDream.wsz
EOF
xcodegen generate
```

Verify license terms per source before redistributing. The Webamp Skin Museum (`skins.webamp.org`) is a good source for permissive Winamp 2.x skins; MIT-licensed picks from the Webamp project's demo set are the safest.

Issue stays open until the actual skins land. Once they do, that PR can update `TESTING.md` section E with the new total + names and close #24.

## Test plan
- [x] Build green on iPhone 17 sim (no source-code changes; just docs + helper script).
- [ ] Run `./scripts/fetch-extra-skins.sh` with a sample URL list → files appear in `Resources/Skins/` with the right names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
