### PR TITLE
Smart Play: AI modes — Vibe Match, Storyteller, Sonic Contrast (closes #25)

### DIFF
--- a/HarmonIQ.xcodeproj/project.pbxproj
+++ b/HarmonIQ.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		01E3439E649010D829D7AB8A /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF43538DAF9F07E1F7428FE1 /* SettingsView.swift */; };
 		0323B3047D47591B359097DF /* AlbumsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D685B9A89C2B6EDCCCB4AB /* AlbumsView.swift */; };
 		0875DAB5569B83DC801CA7B8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4D55B677D3210BEAEDFEA0C5 /* Assets.xcassets */; };
+		09DB5BB6958F7981EAFF5EED /* SmartPlayAI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A3E5FF59C499E1F16218AA /* SmartPlayAI.swift */; };
 		116A7F3DD4FF063CD5776F50 /* LiveActivityController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2650366DAD3EEB077B33CD /* LiveActivityController.swift */; };
 		16F8F24D50C9EB96562011DC /* SmartPlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = A31A65F1BCE09BD374018CC4 /* SmartPlay.swift */; };
 		3623E19150C55CECDF8DF6BE /* HarmonIQActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4F2B572BEA8AA004255D82 /* HarmonIQActivityAttributes.swift */; };
@@ -20,6 +21,7 @@
 		409179BD52B576D6D435FD06 /* NowPlayingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B633D01EE0A630588055E78D /* NowPlayingManager.swift */; };
 		492B4DC977A439789D0DA1D9 /* VisualizerSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15226D22B73C8F0CE0719B80 /* VisualizerSettingsView.swift */; };
 		4ADB0C6545C514B0C7DD74BC /* SkinManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4AF615B9FD22338A53B687E /* SkinManager.swift */; };
+		4BAC40B449B110A162FC0AE2 /* AnthropicClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AEFD2723ADD2EC828F5588 /* AnthropicClient.swift */; };
 		4F0642BBF49AF0AD060D3949 /* Playlist.swift in Sources */ = {isa = PBXBuildFile; fileRef = D210ACF5D89E9E21A1496719 /* Playlist.swift */; };
 		5CCAA8466F69FB84BF8B02A6 /* SharedComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 347E6294D599CCE0B3003D2E /* SharedComponents.swift */; };
 		5DB383E665EE8EAE33D78E9C /* LibraryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F130079612D4D04F3BDAF75 /* LibraryStore.swift */; };
@@ -61,6 +63,7 @@
 		E1D2A557F273963F3ABFCFC5 /* AllTracksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0243B50E58BF70DF26D99D0 /* AllTracksView.swift */; };
 		EC778E91CBFC41C1A6A09A2A /* Visualizers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A922A09FC20BC24E0180727 /* Visualizers.swift */; };
 		F01E667FD20EFB46CB5AF202 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32550B9D7779BCA0DDA5827D /* SearchView.swift */; };
+		FC4B30F8B53A01684F54C45E /* AISettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E4AE5698FC27796904A4105 /* AISettingsView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -104,6 +107,7 @@
 		645788E38767A20E50B440A4 /* SkinnedVolumeSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkinnedVolumeSlider.swift; sourceTree = "<group>"; };
 		6A922A09FC20BC24E0180727 /* Visualizers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Visualizers.swift; sourceTree = "<group>"; };
 		6E48BCF53895F042489D6F8B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		6E4AE5698FC27796904A4105 /* AISettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISettingsView.swift; sourceTree = "<group>"; };
 		7D9E86967B7801F70269E055 /* Skins */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Skins; path = HarmonIQ/Resources/Skins; sourceTree = SOURCE_ROOT; };
 		8CA5D219A5FF2CBA19A0E003 /* LibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryView.swift; sourceTree = "<group>"; };
 		91184AF88772B10074EACE0A /* SkinnedEqualizerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkinnedEqualizerView.swift; sourceTree = "<group>"; };
@@ -124,9 +128,11 @@
 		BAE503899DE0AC71DEE6E6B7 /* SmartPlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartPlayView.swift; sourceTree = "<group>"; };
 		BB566E7DBDC9F95DA534869C /* ScrollingBitmapText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollingBitmapText.swift; sourceTree = "<group>"; };
 		BEFB4D3197C2EC465A4B964C /* DriveLibraryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DriveLibraryStore.swift; sourceTree = "<group>"; };
+		C0AEFD2723ADD2EC828F5588 /* AnthropicClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnthropicClient.swift; sourceTree = "<group>"; };
 		C20AD805166CAC672F2833BC /* HarmonIQ.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = HarmonIQ.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C4D685B9A89C2B6EDCCCB4AB /* AlbumsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumsView.swift; sourceTree = "<group>"; };
 		C6203F24B0D3D962883456DA /* SpriteButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpriteButton.swift; sourceTree = "<group>"; };
+		C9A3E5FF59C499E1F16218AA /* SmartPlayAI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartPlayAI.swift; sourceTree = "<group>"; };
 		CB2650366DAD3EEB077B33CD /* LiveActivityController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityController.swift; sourceTree = "<group>"; };
 		CC4F2B572BEA8AA004255D82 /* HarmonIQActivityAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarmonIQActivityAttributes.swift; sourceTree = "<group>"; };
 		CE5341339CB5BD57C71DD7EC /* BitmapSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitmapSlider.swift; sourceTree = "<group>"; };
@@ -223,6 +229,7 @@
 			isa = PBXGroup;
 			children = (
 				26B82CBABF6097B115C7FD68 /* Skin */,
+				6E4AE5698FC27796904A4105 /* AISettingsView.swift */,
 				C4D685B9A89C2B6EDCCCB4AB /* AlbumsView.swift */,
 				D0243B50E58BF70DF26D99D0 /* AllTracksView.swift */,
 				21D6E4A738A357E6A860D0E0 /* ArtistsView.swift */,
@@ -264,10 +271,12 @@
 		8B9672760105FAA96F2576E3 /* Player */ = {
 			isa = PBXGroup;
 			children = (
+				C0AEFD2723ADD2EC828F5588 /* AnthropicClient.swift */,
 				978941B5C224F0EFA9E46A90 /* AudioPlayerManager.swift */,
 				1747349698811EB8ADA561A3 /* EqualizerManager.swift */,
 				B633D01EE0A630588055E78D /* NowPlayingManager.swift */,
 				A31A65F1BCE09BD374018CC4 /* SmartPlay.swift */,
+				C9A3E5FF59C499E1F16218AA /* SmartPlayAI.swift */,
 			);
 			path = Player;
 			sourceTree = "<group>";
@@ -424,8 +433,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FC4B30F8B53A01684F54C45E /* AISettingsView.swift in Sources */,
 				0323B3047D47591B359097DF /* AlbumsView.swift in Sources */,
 				E1D2A557F273963F3ABFCFC5 /* AllTracksView.swift in Sources */,
+				4BAC40B449B110A162FC0AE2 /* AnthropicClient.swift in Sources */,
 				DA3451E853523F3F3794A302 /* ArtistsView.swift in Sources */,
 				DCF4418A459E115EF770E6D9 /* AudioPlayerManager.swift in Sources */,
 				791A8D34EE8AB6E905502339 /* BitmapNumbers.swift in Sources */,
@@ -463,6 +474,7 @@
 				89D7DBC59590AF415A3B0191 /* SkinnedVolumeSlider.swift in Sources */,
 				3C97B812BAD6F65814E216E6 /* SleepTimerViews.swift in Sources */,
 				16F8F24D50C9EB96562011DC /* SmartPlay.swift in Sources */,
+				09DB5BB6958F7981EAFF5EED /* SmartPlayAI.swift in Sources */,
 				77B3E1181A2A2CBFAD277C5E /* SmartPlayView.swift in Sources */,
 				69A2102040E365274784D9BD /* SpriteButton.swift in Sources */,
 				75DC9743887154D3D3823A75 /* Track.swift in Sources */,

--- a/HarmonIQ/Player/AnthropicClient.swift
+++ b/HarmonIQ/Player/AnthropicClient.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+/// Minimal async client for the Anthropic Messages API. Used by the AI
+/// Smart Play modes (Vibe Match, Storyteller, Sonic Contrast — issue #25).
+///
+/// Stays small on purpose: no SDK dep, no streaming, no tool use, no
+/// retries. The user provides their own API key via Settings; the key is
+/// stored in UserDefaults (not the Keychain — this is a personal-library
+/// app and the user already trusts the device with their own key).
+enum AnthropicClient {
+    /// Default model for Smart Play curation calls. Haiku 4.5 keeps the
+    /// round-trip latency low — track-list selection from a manifest is
+    /// well within Haiku's strengths and the user is waiting on a
+    /// progress spinner.
+    static let defaultModel = "claude-haiku-4-5-20251001"
+
+    /// UserDefaults key for the user-supplied Anthropic API key.
+    static let apiKeyDefaultsKey = "harmoniq.anthropic.apiKey"
+
+    static var apiKey: String? {
+        let v = UserDefaults.standard.string(forKey: apiKeyDefaultsKey) ?? ""
+        return v.isEmpty ? nil : v
+    }
+
+    static var isConfigured: Bool { apiKey != nil }
+
+    enum ClientError: Error, LocalizedError {
+        case missingAPIKey
+        case httpError(Int, String)
+        case decodeError(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .missingAPIKey:
+                return "Add your Anthropic API key in Settings → AI to use this mode."
+            case .httpError(let code, let body):
+                return "Anthropic API error \(code): \(body)"
+            case .decodeError(let detail):
+                return "Couldn't read the model's response: \(detail)"
+            }
+        }
+    }
+
+    /// Send a single-turn prompt and return the assistant's plain-text
+    /// response. The system prompt is marked as cacheable (5 min TTL) so
+    /// repeated curations within a session are cheaper.
+    static func send(systemPrompt: String,
+                     userPrompt: String,
+                     model: String = defaultModel,
+                     maxTokens: Int = 4096) async throws -> String {
+        guard let key = apiKey else { throw ClientError.missingAPIKey }
+
+        let url = URL(string: "https://api.anthropic.com/v1/messages")!
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.setValue(key, forHTTPHeaderField: "x-api-key")
+        req.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        // Prompt-caching beta header — system prompts get a 5 min TTL.
+        req.setValue("prompt-caching-2024-07-31", forHTTPHeaderField: "anthropic-beta")
+
+        let body: [String: Any] = [
+            "model": model,
+            "max_tokens": maxTokens,
+            "system": [
+                ["type": "text", "text": systemPrompt, "cache_control": ["type": "ephemeral"]],
+            ],
+            "messages": [
+                ["role": "user", "content": userPrompt]
+            ]
+        ]
+        req.httpBody = try JSONSerialization.data(withJSONObject: body, options: [])
+
+        let (data, resp) = try await URLSession.shared.data(for: req)
+        guard let http = resp as? HTTPURLResponse else {
+            throw ClientError.httpError(-1, "no response")
+        }
+        if http.statusCode >= 400 {
+            let bodyStr = String(data: data, encoding: .utf8) ?? "<binary>"
+            throw ClientError.httpError(http.statusCode, bodyStr)
+        }
+
+        // Parse the response shape: { content: [ { type: "text", text: "..." }, ... ] }
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let content = json["content"] as? [[String: Any]] else {
+            throw ClientError.decodeError("unexpected envelope")
+        }
+        let text = content.compactMap { $0["text"] as? String }.joined()
+        if text.isEmpty {
+            throw ClientError.decodeError("empty content")
+        }
+        return text
+    }
+}
+
+/// UserDefaults-backed configuration for the AI features. Exposed as a
+/// small ObservableObject so the Settings UI binds cleanly.
+@MainActor
+final class AnthropicSettings: ObservableObject {
+    static let shared = AnthropicSettings()
+
+    @Published var apiKey: String {
+        didSet { UserDefaults.standard.set(apiKey, forKey: AnthropicClient.apiKeyDefaultsKey) }
+    }
+
+    init() {
+        self.apiKey = UserDefaults.standard.string(forKey: AnthropicClient.apiKeyDefaultsKey) ?? ""
+    }
+
+    var isConfigured: Bool { !apiKey.isEmpty }
+}

--- a/HarmonIQ/Player/AudioPlayerManager.swift
+++ b/HarmonIQ/Player/AudioPlayerManager.swift
@@ -42,6 +42,10 @@ final class AudioPlayerManager: NSObject, ObservableObject {
     }
     @Published var repeatMode: RepeatMode = .off
     @Published private(set) var activeSmartMode: SmartPlayMode? = nil
+    /// Non-nil while an AI Smart Play call is in flight. UI shows a spinner.
+    @Published private(set) var aiCurating: SmartPlayMode? = nil
+    /// Title + blurb returned by the most recent AI curation, for UI display.
+    @Published private(set) var aiAnnotation: AIQueueAnnotation? = nil
 
     /// 0...1 master volume. Mapped to the player node's `volume` directly.
     @Published var volume: Float = 0.85 {
@@ -232,7 +236,29 @@ final class AudioPlayerManager: NSObject, ObservableObject {
         guard !queue.isEmpty else { return }
         activeSmartMode = mode
         isShuffleEnabled = false
+        aiAnnotation = nil
         loadQueue(queue, startIndex: 0)
+        playCurrent()
+        presentNowPlayingTick &+= 1
+    }
+
+    /// Build + play an AI-curated queue. `userPrompt` is only meaningful for
+    /// `.vibeMatch`. Throws if the API key is missing or the call fails so
+    /// the UI can present an error to the user.
+    func playSmartAI(mode: SmartPlayMode, from pool: [Track], userPrompt: String = "") async throws {
+        guard mode.requiresAI else { return }
+        guard !pool.isEmpty else { return }
+        aiCurating = mode
+        defer { aiCurating = nil }
+        let curated = try await SmartPlayAI.curate(mode: mode, userPrompt: userPrompt, pool: pool)
+        // Map the returned stableIDs back to in-memory Tracks.
+        let map: [String: Track] = Dictionary(uniqueKeysWithValues: pool.map { ($0.stableID, $0) })
+        let resolved: [Track] = curated.trackIDs.compactMap { map[$0] }
+        guard !resolved.isEmpty else { return }
+        activeSmartMode = mode
+        isShuffleEnabled = false
+        aiAnnotation = AIQueueAnnotation(title: curated.title, blurb: curated.blurb, rationales: curated.rationales)
+        loadQueue(resolved, startIndex: 0)
         playCurrent()
         presentNowPlayingTick &+= 1
     }
@@ -629,6 +655,18 @@ final class AudioPlayerManager: NSObject, ObservableObject {
             onSeek: { [weak self] time in self?.seek(to: time) }
         )
     }
+}
+
+// MARK: - AI Queue annotation
+
+/// Per-queue framing returned by the AI Smart Play modes (issue #25).
+/// Lives on `AudioPlayerManager.aiAnnotation` while the AI-curated queue
+/// is active; cleared when the user starts a non-AI playback.
+struct AIQueueAnnotation: Equatable {
+    let title: String
+    let blurb: String
+    /// One-line rationale per stableID, when the model provided one.
+    let rationales: [String: String]
 }
 
 // MARK: - Meter sink

--- a/HarmonIQ/Player/SmartPlay.swift
+++ b/HarmonIQ/Player/SmartPlay.swift
@@ -15,8 +15,21 @@ enum SmartPlayMode: String, CaseIterable, Identifiable {
     case onePerArtist
     case genreTunnel
     case eraWalk
+    // AI-assisted modes (issue #25). Require an Anthropic API key configured
+    // in Settings → AI; the modes are visible but disabled until then.
+    case vibeMatch
+    case storyteller
+    case sonicContrast
 
     var id: String { rawValue }
+
+    /// True when this mode requires an Anthropic API call to build the queue.
+    var requiresAI: Bool {
+        switch self {
+        case .vibeMatch, .storyteller, .sonicContrast: return true
+        default: return false
+        }
+    }
 
     var title: String {
         switch self {
@@ -34,6 +47,9 @@ enum SmartPlayMode: String, CaseIterable, Identifiable {
         case .onePerArtist:   return "One Per Artist"
         case .genreTunnel:    return "Genre Tunnel"
         case .eraWalk:        return "Era Walk"
+        case .vibeMatch:      return "Vibe Match"
+        case .storyteller:    return "Storyteller"
+        case .sonicContrast:  return "Sonic Contrast"
         }
     }
 
@@ -53,6 +69,9 @@ enum SmartPlayMode: String, CaseIterable, Identifiable {
         case .onePerArtist:   return "Exactly one track per artist. Maximum breadth in one sitting."
         case .genreTunnel:    return "Stays inside one genre — seeded by what's playing, or the biggest in the library."
         case .eraWalk:        return "Chronological tour — earliest year first, walking forward through the decades."
+        case .vibeMatch:      return "AI-curated. Type a vibe — Claude builds a matching queue."
+        case .storyteller:    return "AI-curated. Claude assembles an 8-12 track narrative arc with a blurb."
+        case .sonicContrast:  return "AI-curated. Adjacent tracks are intentionally distinct in style."
         }
     }
 
@@ -72,6 +91,9 @@ enum SmartPlayMode: String, CaseIterable, Identifiable {
         case .onePerArtist:   return "person.3"
         case .genreTunnel:    return "tunnel"
         case .eraWalk:        return "clock.arrow.circlepath"
+        case .vibeMatch:      return "text.bubble"
+        case .storyteller:    return "book"
+        case .sonicContrast:  return "arrow.left.arrow.right"
         }
     }
 }
@@ -211,6 +233,14 @@ enum SmartPlayBuilder {
                 return lhs.displayTitle.localizedStandardCompare(rhs.displayTitle) == .orderedAscending
             }
             return sortedKnown + withoutYear.shuffled()
+
+        case .vibeMatch, .storyteller, .sonicContrast:
+            // AI-curated modes go through `SmartPlayAI.curate` on the async
+            // path. The sync builder is invoked in places that don't expect
+            // a network round-trip, so fall back to a Pure Random shuffle —
+            // the user-facing entry point (`AudioPlayerManager.playSmartAI`)
+            // calls the AI directly instead of this builder.
+            return pool.shuffled()
         }
     }
 

--- a/HarmonIQ/Player/SmartPlayAI.swift
+++ b/HarmonIQ/Player/SmartPlayAI.swift
@@ -1,0 +1,168 @@
+import Foundation
+
+/// AI-driven Smart Play curation. Three modes per issue #25:
+///   - Vibe Match: free-text user prompt → curated queue + per-track rationales
+///   - Storyteller: model picks a thematic 8–12 track narrative arc
+///   - Sonic Contrast: alternates between stylistically different tracks
+///
+/// All three call the same Anthropic Messages endpoint with a manifest of
+/// the library; the JSON response specifies which `stableID`s to play in
+/// what order.
+enum SmartPlayAI {
+    /// What the model returns + a sortable view of the library it saw.
+    struct Curated {
+        let title: String
+        let blurb: String
+        let trackIDs: [String]
+        /// Per-track one-liner rationale, keyed by stableID.
+        let rationales: [String: String]
+    }
+
+    /// Maximum tracks we send in the manifest. Caps token cost on huge
+    /// libraries; the model still has plenty to choose from.
+    static let manifestCap = 1000
+
+    static func curate(mode: SmartPlayMode, userPrompt: String, pool: [Track]) async throws -> Curated {
+        let manifest = compactManifest(pool: pool)
+        let systemPrompt = systemPrompt(for: mode)
+        let userText = """
+        \(userPromptPreamble(for: mode, userText: userPrompt))
+
+        Library (\(manifest.count) tracks):
+        \(jsonString(manifest))
+
+        Return ONLY a JSON object with this shape (no markdown fence, no commentary):
+        {
+          "title": "<short queue title>",
+          "blurb": "<one short paragraph framing the queue>",
+          "queue": [
+            {"id": "<stableID from the library>", "why": "<one sentence rationale>"}
+          ]
+        }
+        """
+
+        let raw = try await AnthropicClient.send(systemPrompt: systemPrompt, userPrompt: userText)
+        return try parse(raw: raw)
+    }
+
+    // MARK: - Prompt construction
+
+    private static func systemPrompt(for mode: SmartPlayMode) -> String {
+        let baseline = """
+        You are an expert music curator embedded in HarmonIQ, a personal
+        music player. The user gives you their full music library as a
+        compact JSON manifest, plus a curation goal. Your job is to pick
+        an ordered queue of `stableID`s (a subset of the manifest) and
+        give a one-sentence rationale per track.
+
+        Hard constraints:
+        - Only use `stableID` values that appear in the supplied manifest.
+          Never invent IDs.
+        - Output is JSON only, with the exact shape specified by the user.
+        - Keep `blurb` under 280 characters.
+        - Aim for 12-25 tracks unless the goal explicitly asks for fewer.
+        - Order matters — sequence is part of the curation.
+        """
+
+        switch mode {
+        case .vibeMatch:
+            return baseline + "\n\nVibe Match: pick tracks that match the mood the user describes; rationales explain *why* each one fits."
+        case .storyteller:
+            return baseline + "\n\nStoryteller: build a narrative arc — a beginning, a peak, a resolution. The blurb names the arc; rationales explain each track's role in it."
+        case .sonicContrast:
+            return baseline + "\n\nSonic Contrast: alternate between stylistically different tracks (genre, energy, era) so adjacent tracks feel intentionally distinct. Rationales describe the contrast pivot."
+        default:
+            return baseline
+        }
+    }
+
+    private static func userPromptPreamble(for mode: SmartPlayMode, userText: String) -> String {
+        switch mode {
+        case .vibeMatch:
+            let trimmed = userText.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty
+                ? "Goal: pick a vibe at random and run with it."
+                : "Vibe prompt from the user: \(trimmed)"
+        case .storyteller:
+            return "Goal: assemble a thematic mini-album — 8 to 12 tracks that tell one story."
+        case .sonicContrast:
+            return "Goal: build a queue where adjacent tracks contrast sharply in style."
+        default:
+            return "Goal: pick a curated queue."
+        }
+    }
+
+    // MARK: - Manifest
+
+    private struct ManifestEntry: Encodable {
+        let id: String
+        let title: String
+        let artist: String
+        let album: String
+        let year: Int?
+        let genre: String?
+        let durationSec: Int
+    }
+
+    private static func compactManifest(pool: [Track]) -> [ManifestEntry] {
+        // Cap to keep tokens low; sample the front end of the library —
+        // shuffle could miss recently-indexed tracks, and slicing is
+        // cheaper than a real sample for the typical case.
+        let limited = pool.prefix(manifestCap)
+        return limited.map { t in
+            ManifestEntry(
+                id: t.stableID,
+                title: t.displayTitle,
+                artist: t.displayArtist,
+                album: t.displayAlbum,
+                year: t.year,
+                genre: t.genre?.nilIfBlank,
+                durationSec: Int(t.duration.rounded())
+            )
+        }
+    }
+
+    private static func jsonString<T: Encodable>(_ value: T) -> String {
+        let enc = JSONEncoder()
+        enc.outputFormatting = [.sortedKeys] // deterministic for caching
+        guard let data = try? enc.encode(value),
+              let s = String(data: data, encoding: .utf8) else { return "[]" }
+        return s
+    }
+
+    // MARK: - Parsing
+
+    private static func parse(raw: String) throws -> Curated {
+        // Models occasionally wrap JSON in fences despite explicit "no markdown" — strip.
+        let trimmed = stripCodeFence(raw.trimmingCharacters(in: .whitespacesAndNewlines))
+        guard let data = trimmed.data(using: .utf8),
+              let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw AnthropicClient.ClientError.decodeError("not JSON: \(raw.prefix(200))")
+        }
+        let title = (obj["title"] as? String) ?? "Smart Mix"
+        let blurb = (obj["blurb"] as? String) ?? ""
+        guard let queue = obj["queue"] as? [[String: Any]] else {
+            throw AnthropicClient.ClientError.decodeError("missing `queue` array")
+        }
+        var trackIDs: [String] = []
+        var rationales: [String: String] = [:]
+        for entry in queue {
+            guard let id = entry["id"] as? String else { continue }
+            trackIDs.append(id)
+            if let why = entry["why"] as? String { rationales[id] = why }
+        }
+        return Curated(title: title, blurb: blurb, trackIDs: trackIDs, rationales: rationales)
+    }
+
+    private static func stripCodeFence(_ s: String) -> String {
+        guard s.hasPrefix("```") else { return s }
+        // Drop the opening fence (and an optional language tag), then find
+        // the closing fence and drop it.
+        var rest = s.dropFirst(3)
+        if let nl = rest.firstIndex(of: "\n") { rest = rest[rest.index(after: nl)...] }
+        if let close = rest.range(of: "```", options: .backwards) {
+            rest = rest[..<close.lowerBound]
+        }
+        return String(rest).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/HarmonIQ/Views/AISettingsView.swift
+++ b/HarmonIQ/Views/AISettingsView.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+/// Settings → AI Smart Play. Captures the user's Anthropic API key and
+/// shows the connection state. The key is persisted to UserDefaults.
+struct AISettingsView: View {
+    @StateObject private var settings = AnthropicSettings.shared
+    @State private var revealKey = false
+
+    var body: some View {
+        List {
+            Section {
+                if revealKey {
+                    TextField("sk-ant-…", text: $settings.apiKey)
+                        .textInputAutocapitalization(.never)
+                        .disableAutocorrection(true)
+                        .font(.system(.body, design: .monospaced))
+                } else {
+                    SecureField("sk-ant-…", text: $settings.apiKey)
+                        .textInputAutocapitalization(.never)
+                        .disableAutocorrection(true)
+                        .font(.system(.body, design: .monospaced))
+                }
+                Toggle("Show key", isOn: $revealKey)
+                if !settings.apiKey.isEmpty {
+                    Button(role: .destructive) {
+                        settings.apiKey = ""
+                    } label: {
+                        Label("Remove key", systemImage: "trash")
+                    }
+                }
+            } header: {
+                Text("Anthropic API Key")
+            } footer: {
+                Text("Your key is stored only on this device (UserDefaults). Get a key from console.anthropic.com — small Smart Play calls run on Claude Haiku and are inexpensive.")
+            }
+
+            Section {
+                LabeledContent("Status",
+                               value: settings.isConfigured ? "Configured" : "Not configured")
+                LabeledContent("Default model", value: AnthropicClient.defaultModel)
+            } header: {
+                Text("Status")
+            }
+
+            Section {
+                Text("**Vibe Match** — type a free-text vibe (e.g. ‟rainy afternoon”). Claude picks tracks from your library that fit.")
+                Text("**Storyteller** — Claude assembles a thematic 8-12 track narrative arc with a short blurb at the top of the queue.")
+                Text("**Sonic Contrast** — alternates between stylistically different tracks to keep the listener engaged.")
+            } header: {
+                Text("AI Modes")
+            } footer: {
+                Text("Each call sends a compact manifest of your library (title/artist/album/year/duration only — no audio) to Anthropic and receives an ordered list of stableIDs back.")
+            }
+        }
+        .navigationTitle("AI Smart Play")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/HarmonIQ/Views/SettingsView.swift
+++ b/HarmonIQ/Views/SettingsView.swift
@@ -57,6 +57,18 @@ struct SettingsView: View {
                 Text("Appearance")
             }
 
+            Section {
+                NavigationLink {
+                    AISettingsView()
+                } label: {
+                    Label("AI Smart Play", systemImage: "wand.and.stars")
+                }
+            } header: {
+                Text("AI")
+            } footer: {
+                Text("Optional — adds AI-driven Smart Play modes (Vibe Match, Storyteller, Sonic Contrast). Bring your own Anthropic API key. Calls are billed to your account.")
+            }
+
             Section("About") {
                 LabeledContent("App", value: "HarmonIQ")
                 LabeledContent("Version", value: "1.0")

--- a/HarmonIQ/Views/SmartPlayView.swift
+++ b/HarmonIQ/Views/SmartPlayView.swift
@@ -3,6 +3,13 @@ import SwiftUI
 struct SmartPlayView: View {
     @EnvironmentObject var library: LibraryStore
     @EnvironmentObject var player: AudioPlayerManager
+    @StateObject private var aiSettings = AnthropicSettings.shared
+    @State private var vibeMatchPrompt: String = ""
+    @State private var showVibePrompt = false
+    @State private var aiError: String?
+
+    private var ruleBasedModes: [SmartPlayMode] { SmartPlayMode.allCases.filter { !$0.requiresAI } }
+    private var aiModes: [SmartPlayMode] { SmartPlayMode.allCases.filter { $0.requiresAI } }
 
     var body: some View {
         Group {
@@ -18,8 +25,45 @@ struct SmartPlayView: View {
                             .foregroundStyle(.secondary)
                     }
                     Section {
-                        ForEach(SmartPlayMode.allCases) { mode in
-                            SmartPlayRow(mode: mode, pool: library.tracks)
+                        ForEach(ruleBasedModes) { mode in
+                            SmartPlayRow(mode: mode, pool: library.tracks, onTap: { play(mode: $0) })
+                        }
+                    }
+                    Section {
+                        ForEach(aiModes) { mode in
+                            SmartPlayRow(mode: mode,
+                                         pool: library.tracks,
+                                         disabled: !aiSettings.isConfigured,
+                                         onTap: { play(mode: $0) })
+                        }
+                        if !aiSettings.isConfigured {
+                            NavigationLink {
+                                AISettingsView()
+                            } label: {
+                                Label("Add Anthropic API key in Settings", systemImage: "key")
+                                    .font(.caption)
+                                    .foregroundStyle(.tint)
+                            }
+                        }
+                    } header: {
+                        HStack(spacing: 4) {
+                            Image(systemName: "wand.and.stars")
+                            Text("AI-CURATED")
+                        }
+                    } footer: {
+                        if let curating = player.aiCurating {
+                            HStack(spacing: 6) {
+                                ProgressView().controlSize(.small)
+                                Text("Claude is curating \(curating.title)…")
+                                    .font(.caption)
+                            }
+                        } else if let annotation = player.aiAnnotation {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(annotation.title).font(.caption.bold())
+                                Text(annotation.blurb).font(.caption)
+                            }
+                            .foregroundStyle(.secondary)
+                            .padding(.top, 4)
                         }
                     }
                 }
@@ -28,17 +72,59 @@ struct SmartPlayView: View {
         }
         .navigationTitle("Smart Play")
         .navigationBarTitleDisplayMode(.inline)
+        .alert("Vibe Match", isPresented: $showVibePrompt) {
+            TextField("rainy afternoon, pre-workout hype, …", text: $vibeMatchPrompt)
+            Button("Curate") {
+                runAI(mode: .vibeMatch, prompt: vibeMatchPrompt)
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Type a free-text vibe. Claude will pick tracks from your library that match.")
+        }
+        .alert("Curation failed", isPresented: Binding(
+            get: { aiError != nil },
+            set: { if !$0 { aiError = nil } }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(aiError ?? "")
+        }
+    }
+
+    private func play(mode: SmartPlayMode) {
+        if mode == .vibeMatch {
+            vibeMatchPrompt = ""
+            showVibePrompt = true
+            return
+        }
+        if mode.requiresAI {
+            runAI(mode: mode, prompt: "")
+            return
+        }
+        player.playSmart(mode: mode, from: library.tracks)
+    }
+
+    private func runAI(mode: SmartPlayMode, prompt: String) {
+        Task {
+            do {
+                try await player.playSmartAI(mode: mode, from: library.tracks, userPrompt: prompt)
+            } catch {
+                aiError = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            }
+        }
     }
 }
 
 private struct SmartPlayRow: View {
     let mode: SmartPlayMode
     let pool: [Track]
+    var disabled: Bool = false
+    let onTap: (SmartPlayMode) -> Void
     @EnvironmentObject var player: AudioPlayerManager
 
     var body: some View {
         Button {
-            player.playSmart(mode: mode, from: pool)
+            onTap(mode)
         } label: {
             HStack(alignment: .top, spacing: 14) {
                 ZStack {
@@ -54,12 +140,14 @@ private struct SmartPlayRow: View {
                     HStack {
                         Text(mode.title)
                             .font(.body.weight(.semibold))
-                            .foregroundStyle(Color.primary)
+                            .foregroundStyle(disabled ? Color.secondary : Color.primary)
                         Spacer()
                         if player.activeSmartMode == mode {
                             Image(systemName: "speaker.wave.2.fill")
                                 .font(.caption)
                                 .foregroundStyle(Color.accentColor)
+                        } else if player.aiCurating == mode {
+                            ProgressView().controlSize(.small)
                         }
                     }
                     Text(mode.subtitle)
@@ -77,6 +165,7 @@ private struct SmartPlayRow: View {
             .padding(.vertical, 4)
         }
         .buttonStyle(.plain)
+        .disabled(disabled)
     }
 
     /// For modes that filter on duration, show a quick count so users know the pool isn't empty.

--- a/TESTING.md
+++ b/TESTING.md
@@ -126,6 +126,14 @@ If a section is irrelevant to your PR (e.g. you only touched skin loading), stil
 - [ ] **Era Walk**: queue is in non-decreasing year order (earliest first); tracks without a year appear at the end.
 - [ ] At least one of (Album Walk, Artist Roulette, Discovery Mix) still builds a sensible queue and plays — regression check.
 
+### AI Smart Play (issue #25)
+
+- [ ] Without an API key configured: the **AI-CURATED** section's three rows (Vibe Match, Storyteller, Sonic Contrast) are visible but disabled, and a "Add Anthropic API key in Settings" link is shown.
+- [ ] Settings → AI Smart Play: paste a valid `sk-ant-…` key → status flips to "Configured"; the Smart Play AI rows become enabled.
+- [ ] **Vibe Match**: tap the row → an alert prompts for a free-text vibe → enter "rainy afternoon" → a spinner appears in the section footer ("Claude is curating Vibe Match…") → a queue plays and the footer shows the title + blurb returned by the model.
+- [ ] **Storyteller** / **Sonic Contrast**: tap → queue starts without a prompt; footer shows model-generated title + blurb.
+- [ ] Network error (airplane mode mid-call) surfaces as an alert; UI returns to idle.
+
 ---
 
 ## I. Visualizer styles (SwiftUI player)


### PR DESCRIPTION
## Summary
Adds the three AI-driven Smart Play modes from issue #25:

| Mode | What it does |
|---|---|
| **Vibe Match** | User types a free-text vibe (e.g. "rainy afternoon"). Claude picks tracks that fit. |
| **Storyteller** | Claude assembles an 8-12 track narrative arc with a short blurb at the top. |
| **Sonic Contrast** | Alternates between stylistically distinct adjacent tracks. |

Each call sends a compact JSON manifest of the library (stableID + title/artist/album/year/genre/duration, capped at 1000 tracks) to Anthropic's `/v1/messages` and parses the JSON response into an ordered queue + per-track rationales + a queue title/blurb shown in the Smart Play footer.

## Architecture
| File | Purpose |
|---|---|
| `HarmonIQ/Player/AnthropicClient.swift` | Minimal async client. Prompt-caching beta header on the system prompt for cheaper repeat curations. |
| `HarmonIQ/Player/SmartPlayAI.swift` | Manifest builder, prompt templates per mode, JSON parser (with a code-fence stripper for stubborn markdown wrapping). |
| `HarmonIQ/Player/AudioPlayerManager.swift` | `playSmartAI(...)` async method, `@Published aiCurating` + `aiAnnotation` for spinner/footer. |
| `HarmonIQ/Views/AISettingsView.swift` | Settings → AI page. SecureField for the API key + reveal toggle, status, model name. |
| `HarmonIQ/Views/SmartPlayView.swift` | Splits the Smart Play list into rule-based and AI-curated sections. AI rows are disabled until a key is configured. |

## Key handling
- Stored in UserDefaults under `harmoniq.anthropic.apiKey` (this is a personal-library app on the user's device — Keychain wasn't worth the friction).
- No key is hardcoded.
- No API calls happen at launch — only on explicit user invocation.

## Defaults
- **Model**: `claude-haiku-4-5-20251001` — Haiku is more than capable of curation from a manifest and keeps the round-trip latency low.
- **Manifest cap**: 1000 tracks (front-of-library slice). Easy to bump if needed.

Closes #25.

## Test plan
- [x] Build green on iPhone 17 sim. App cold-launch OK.
- [ ] No API key configured: AI rows visible but disabled, "Add key" link rendered.
- [ ] Settings → AI Smart Play: paste an `sk-ant-…` key → status flips to Configured; AI rows enabled.
- [ ] Vibe Match: tap → prompt alert → enter "rainy afternoon" → spinner in footer → queue starts and footer shows title + blurb.
- [ ] Storyteller / Sonic Contrast: tap → queue starts without a prompt; footer shows model-generated title + blurb.
- [ ] Network error: surfaces as an alert; UI returns to idle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
