### PR TITLE
Visualizer fixes: radial pulse + SwiftUI single-tap (closes #41 #43)

### DIFF
--- a/HarmonIQ/Player/AudioPlayerManager.swift
+++ b/HarmonIQ/Player/AudioPlayerManager.swift
@@ -144,11 +144,12 @@ final class AudioPlayerManager: NSObject, ObservableObject {
         playerNode.volume = volume
         playerNode.pan = balance
         // Tap on the EQ output so the visualizer reflects what the user hears
-        // (post-EQ + post-volume). Tap is installed once and persists for the
-        // lifetime of the process.
-        let tapFormat = eq.outputFormat(forBus: 0)
+        // (post-EQ + post-volume). `format: nil` lets the engine pick the
+        // actual rendered format when the graph starts — querying
+        // `outputFormat(forBus: 0)` *before* `engine.start()` returns a stale
+        // default that the tap then silently mismatches. Issue #41.
         let sink = meterSink
-        eq.installTap(onBus: 0, bufferSize: 1024, format: tapFormat) { buffer, _ in
+        eq.installTap(onBus: 0, bufferSize: 1024, format: nil) { buffer, _ in
             sink.process(buffer: buffer)
         }
     }

--- a/HarmonIQ/Views/Visualizers.swift
+++ b/HarmonIQ/Views/Visualizers.swift
@@ -165,9 +165,14 @@ struct VisualizerView: View {
             .clipShape(RoundedRectangle(cornerRadius: 4))
             .overlay(alignment: .center) { styleToast }
             .contentShape(Rectangle())
-            // Long-press OR double-tap on the surface cycles the style.
+            // Single-tap, double-tap, and long-press all cycle the style. The
+            // skinned (Winamp) player uses single-tap so this matches that
+            // affordance — issue #43. Double-tap stays attached because users
+            // who learned that gesture before still expect it; declaring both
+            // counts coexists fine in SwiftUI's tap dispatch.
             .onLongPressGesture(minimumDuration: 0.4) { cycleAndToast() }
             .onTapGesture(count: 2) { cycleAndToast() }
+            .onTapGesture { cycleAndToast() }
         }
         .bevelPanel(corner: 6)
     }
@@ -555,10 +560,13 @@ private func drawCircle(context: GraphicsContext, size: CGSize, engine: Visualiz
 
     // Bars around the ring.
     let count = bands.count
+    // Apply the same energy-floor pattern as commit 98c92d9 used for the
+    // other styles so quiet bars still register on a small rect (issue #41).
+    let span = maxOuter - innerR
     for i in 0..<count {
         let theta = Double(i) / Double(count) * 2 * .pi - .pi / 2
-        let len = CGFloat(bands[i]) * (maxOuter - innerR)
-        guard len >= 1 else { continue }
+        let len = max(span * 0.05, CGFloat(bands[i]) * span)
+        guard len >= 0.5 else { continue }
         let cosT = CGFloat(cos(theta))
         let sinT = CGFloat(sin(theta))
         let p1 = CGPoint(x: center.x + cosT * innerR, y: center.y + sinT * innerR)


### PR DESCRIPTION
Two small visualizer follow-ups.

## #41 — Radial Pulse not animating

Two contributing fixes:

1. **Metering tap format**: in `AudioPlayerManager.setupAudioGraph`, the EQ-output tap was installed with `eq.outputFormat(forBus: 0)` queried *before* `engine.start()`. That returns a stale default that often doesn't match the actually-rendered format, so the tap callback either fires with a mismatched buffer or doesn't fire at all → `levels` stays near zero → the visualizer's energy floor is the only thing keeping styles alive, and Radial Pulse's stricter `len >= 1` guard drops everything below it. Switching to `format: nil` lets the engine bind the live format when it starts.
2. **Radial Pulse threshold**: clamp `len` to a sub-pixel minimum (`span * 0.05`) and lower the guard from `>= 1` to `>= 0.5` so quiet bars still register on small rects (iPad portrait, in-list previews). Same flooring idea as commit `98c92d9` used for the other styles.

## #43 — Single-tap to cycle in SwiftUI player

Adds `.onTapGesture { cycleAndToast() }` (count: 1) alongside the existing double-tap and long-press handlers in `VisualizerView.body`, matching the skinned-player single-tap behavior from `a35cb5a`. Double-tap and long-press still work.

Closes #41, #43.

## Test plan
- [x] Build green on iPhone 17 sim.
- [ ] Radial Pulse during playback: inner ring pulses with energy; radiating bars appear and react to bands. Bars are visible even on quiet sections.
- [ ] Other visualizer styles unaffected (Spectrum, Oscilloscope, Plasma, Mirror, Particles, Fire, Starfield, all OSC variants).
- [ ] SwiftUI player surface: single-tap cycles to the next style + shows the LCD toast. Double-tap and long-press still cycle.
- [ ] Header `NEXT` button still cycles.
- [ ] Style persists across sheet open/close and app relaunch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
