### PR TITLE
Smart Play: Apple Intelligence (on-device) backend (refs #25)

### DIFF
--- a/HarmonIQ.xcodeproj/project.pbxproj
+++ b/HarmonIQ.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		492B4DC977A439789D0DA1D9 /* VisualizerSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15226D22B73C8F0CE0719B80 /* VisualizerSettingsView.swift */; };
 		4ADB0C6545C514B0C7DD74BC /* SkinManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4AF615B9FD22338A53B687E /* SkinManager.swift */; };
 		4BAC40B449B110A162FC0AE2 /* AnthropicClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AEFD2723ADD2EC828F5588 /* AnthropicClient.swift */; };
+		4BFD5B83D404C76871760396 /* AppleIntelligenceClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A09164BA9759B22CA0598DA5 /* AppleIntelligenceClient.swift */; };
 		4F0642BBF49AF0AD060D3949 /* Playlist.swift in Sources */ = {isa = PBXBuildFile; fileRef = D210ACF5D89E9E21A1496719 /* Playlist.swift */; };
 		5CCAA8466F69FB84BF8B02A6 /* SharedComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 347E6294D599CCE0B3003D2E /* SharedComponents.swift */; };
 		5DB383E665EE8EAE33D78E9C /* LibraryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F130079612D4D04F3BDAF75 /* LibraryStore.swift */; };
@@ -117,6 +118,7 @@
 		9BBB248B178FE1FCF612ED97 /* WinampSkin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WinampSkin.swift; sourceTree = "<group>"; };
 		9D861E89EB0B0713F92113EE /* MusicIndexer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicIndexer.swift; sourceTree = "<group>"; };
 		9F130079612D4D04F3BDAF75 /* LibraryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryStore.swift; sourceTree = "<group>"; };
+		A09164BA9759B22CA0598DA5 /* AppleIntelligenceClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleIntelligenceClient.swift; sourceTree = "<group>"; };
 		A31A65F1BCE09BD374018CC4 /* SmartPlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartPlay.swift; sourceTree = "<group>"; };
 		A4AF615B9FD22338A53B687E /* SkinManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkinManager.swift; sourceTree = "<group>"; };
 		A766E8A1DB63DED492B821BA /* SkinnedPlaylistView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkinnedPlaylistView.swift; sourceTree = "<group>"; };
@@ -272,6 +274,7 @@
 			isa = PBXGroup;
 			children = (
 				C0AEFD2723ADD2EC828F5588 /* AnthropicClient.swift */,
+				A09164BA9759B22CA0598DA5 /* AppleIntelligenceClient.swift */,
 				978941B5C224F0EFA9E46A90 /* AudioPlayerManager.swift */,
 				1747349698811EB8ADA561A3 /* EqualizerManager.swift */,
 				B633D01EE0A630588055E78D /* NowPlayingManager.swift */,
@@ -437,6 +440,7 @@
 				0323B3047D47591B359097DF /* AlbumsView.swift in Sources */,
 				E1D2A557F273963F3ABFCFC5 /* AllTracksView.swift in Sources */,
 				4BAC40B449B110A162FC0AE2 /* AnthropicClient.swift in Sources */,
+				4BFD5B83D404C76871760396 /* AppleIntelligenceClient.swift in Sources */,
 				DA3451E853523F3F3794A302 /* ArtistsView.swift in Sources */,
 				DCF4418A459E115EF770E6D9 /* AudioPlayerManager.swift in Sources */,
 				791A8D34EE8AB6E905502339 /* BitmapNumbers.swift in Sources */,

--- a/HarmonIQ/Player/AnthropicClient.swift
+++ b/HarmonIQ/Player/AnthropicClient.swift
@@ -98,14 +98,33 @@ enum AnthropicClient {
 @MainActor
 final class AnthropicSettings: ObservableObject {
     static let shared = AnthropicSettings()
+    static let useAppleIntelligenceKey = "harmoniq.ai.useAppleIntelligence"
 
     @Published var apiKey: String {
         didSet { UserDefaults.standard.set(apiKey, forKey: AnthropicClient.apiKeyDefaultsKey) }
     }
 
-    init() {
-        self.apiKey = UserDefaults.standard.string(forKey: AnthropicClient.apiKeyDefaultsKey) ?? ""
+    /// When true (and Apple Intelligence is available), AI Smart Play
+    /// routes through the on-device Foundation Models session instead of
+    /// the Anthropic API. No key needed, no network egress.
+    @Published var useAppleIntelligence: Bool {
+        didSet { UserDefaults.standard.set(useAppleIntelligence, forKey: Self.useAppleIntelligenceKey) }
     }
 
-    var isConfigured: Bool { !apiKey.isEmpty }
+    init() {
+        self.apiKey = UserDefaults.standard.string(forKey: AnthropicClient.apiKeyDefaultsKey) ?? ""
+        // Default ON when the user hasn't expressed a preference — local
+        // is strictly better when it's available (free + private). AI
+        // rows fall back to the Anthropic key if Apple Intelligence
+        // rejects at runtime.
+        self.useAppleIntelligence = (UserDefaults.standard.object(forKey: Self.useAppleIntelligenceKey) as? Bool) ?? true
+    }
+
+    /// True when at least one AI backend is usable right now — either
+    /// Apple Intelligence (preferred when toggled on) or a configured
+    /// Anthropic key.
+    var isConfigured: Bool {
+        if useAppleIntelligence && AppleIntelligenceClient.isAvailable { return true }
+        return !apiKey.isEmpty
+    }
 }

--- a/HarmonIQ/Player/AppleIntelligenceClient.swift
+++ b/HarmonIQ/Player/AppleIntelligenceClient.swift
@@ -1,0 +1,121 @@
+import Foundation
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
+/// On-device curator backed by Apple Intelligence's Foundation Models
+/// framework (iOS 26+). When available, AI Smart Play (issue #25) can
+/// run entirely on-device with no API key and no network egress.
+///
+/// Falls back to a clear `unavailable` error on:
+/// - iOS < 26 (framework not present),
+/// - device doesn't support Apple Intelligence (e.g. iPhone 14 or older),
+/// - user hasn't enabled Apple Intelligence in Settings.
+enum AppleIntelligenceClient {
+    enum AvailabilityState {
+        case available
+        case requiresOSUpdate          // OS lacks the framework
+        case deviceNotEligible         // iPhone 14 or older, etc.
+        case appleIntelligenceDisabled // user-toggle off in Settings
+        case modelNotReady             // assets still downloading
+        case unknown(String)
+    }
+
+    enum ClientError: Error, LocalizedError {
+        case unavailable(AvailabilityState)
+        case decodeError(String)
+        case sessionError(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .unavailable(let s):
+                switch s {
+                case .available:
+                    return "Apple Intelligence is available."
+                case .requiresOSUpdate:
+                    return "Apple Intelligence requires iOS 26 or newer."
+                case .deviceNotEligible:
+                    return "This device doesn't support Apple Intelligence. Use the Anthropic API instead, or upgrade to a supported iPhone."
+                case .appleIntelligenceDisabled:
+                    return "Turn on Apple Intelligence in Settings → Apple Intelligence to use the on-device curator."
+                case .modelNotReady:
+                    return "Apple Intelligence is still downloading. Try again in a few minutes."
+                case .unknown(let detail):
+                    return "Apple Intelligence is unavailable: \(detail)"
+                }
+            case .decodeError(let detail):
+                return "Couldn't read the on-device model's response: \(detail)"
+            case .sessionError(let detail):
+                return "On-device session failed: \(detail)"
+            }
+        }
+    }
+
+    /// True when Foundation Models reports the on-device LLM is ready right
+    /// now. Cheap to call repeatedly.
+    static var availability: AvailabilityState {
+        #if canImport(FoundationModels)
+        if #available(iOS 26.0, *) {
+            return mapSystemAvailability()
+        } else {
+            return .requiresOSUpdate
+        }
+        #else
+        return .requiresOSUpdate
+        #endif
+    }
+
+    static var isAvailable: Bool {
+        if case .available = availability { return true }
+        return false
+    }
+
+    /// Send a single-turn instruction + prompt and return the assistant's
+    /// plain-text response. Same signature shape as `AnthropicClient.send`
+    /// so `SmartPlayAI` can dispatch on a flag without restructuring.
+    static func send(systemPrompt: String, userPrompt: String) async throws -> String {
+        #if canImport(FoundationModels)
+        if #available(iOS 26.0, *) {
+            switch mapSystemAvailability() {
+            case .available: break
+            case let other:  throw ClientError.unavailable(other)
+            }
+            do {
+                let session = LanguageModelSession(instructions: systemPrompt)
+                let response = try await session.respond(to: userPrompt)
+                return response.content
+            } catch {
+                throw ClientError.sessionError(String(describing: error))
+            }
+        } else {
+            throw ClientError.unavailable(.requiresOSUpdate)
+        }
+        #else
+        throw ClientError.unavailable(.requiresOSUpdate)
+        #endif
+    }
+
+    #if canImport(FoundationModels)
+    @available(iOS 26.0, *)
+    private static func mapSystemAvailability() -> AvailabilityState {
+        let model = SystemLanguageModel.default
+        switch model.availability {
+        case .available:
+            return .available
+        case .unavailable(let reason):
+            switch reason {
+            case .deviceNotEligible:
+                return .deviceNotEligible
+            case .appleIntelligenceNotEnabled:
+                return .appleIntelligenceDisabled
+            case .modelNotReady:
+                return .modelNotReady
+            @unknown default:
+                return .unknown(String(describing: reason))
+            }
+        @unknown default:
+            return .unknown("unknown availability case")
+        }
+    }
+    #endif
+}

--- a/HarmonIQ/Player/SmartPlayAI.swift
+++ b/HarmonIQ/Player/SmartPlayAI.swift
@@ -41,8 +41,30 @@ enum SmartPlayAI {
         }
         """
 
-        let raw = try await AnthropicClient.send(systemPrompt: systemPrompt, userPrompt: userText)
+        // Pick the backend up-front (read MainActor state once, then drop
+        // back to the actor-free pipeline). Prefer on-device when it's
+        // toggled ON and the system reports the model is ready; fall back
+        // to Anthropic when not.
+        let backend = await pickBackend()
+        let raw: String
+        switch backend {
+        case .appleIntelligence:
+            raw = try await AppleIntelligenceClient.send(systemPrompt: systemPrompt, userPrompt: userText)
+        case .anthropic:
+            raw = try await AnthropicClient.send(systemPrompt: systemPrompt, userPrompt: userText)
+        }
         return try parse(raw: raw)
+    }
+
+    enum Backend { case appleIntelligence, anthropic }
+
+    @MainActor
+    private static func pickBackend() -> Backend {
+        let s = AnthropicSettings.shared
+        if s.useAppleIntelligence && AppleIntelligenceClient.isAvailable {
+            return .appleIntelligence
+        }
+        return .anthropic
     }
 
     // MARK: - Prompt construction

--- a/HarmonIQ/Views/AISettingsView.swift
+++ b/HarmonIQ/Views/AISettingsView.swift
@@ -1,13 +1,62 @@
 import SwiftUI
 
-/// Settings → AI Smart Play. Captures the user's Anthropic API key and
-/// shows the connection state. The key is persisted to UserDefaults.
+/// Settings → AI Smart Play. Lets the user pick between on-device Apple
+/// Intelligence (free, private, iOS 26+) and the Anthropic Messages API
+/// (works on any iOS, requires a key).
 struct AISettingsView: View {
     @StateObject private var settings = AnthropicSettings.shared
     @State private var revealKey = false
+    @State private var availabilityRefreshTick = 0  // forces availability re-check on appear
+
+    private var availability: AppleIntelligenceClient.AvailabilityState {
+        _ = availabilityRefreshTick
+        return AppleIntelligenceClient.availability
+    }
+
+    private var availabilityLabel: String {
+        switch availability {
+        case .available:                  return "Available"
+        case .requiresOSUpdate:           return "Requires iOS 26+"
+        case .deviceNotEligible:          return "Not supported on this device"
+        case .appleIntelligenceDisabled:  return "Disabled in Settings"
+        case .modelNotReady:              return "Downloading…"
+        case .unknown(let s):             return "Unavailable (\(s))"
+        }
+    }
+
+    private var availabilityFooter: String {
+        switch availability {
+        case .available:
+            return "On-device curation runs entirely on your iPhone — no API key, no network egress, free. Smart Play uses Apple's foundation model when this toggle is on."
+        case .requiresOSUpdate:
+            return "Apple Intelligence's foundation models ship with iOS 26. Update iOS or use the Anthropic API below."
+        case .deviceNotEligible:
+            return "Apple Intelligence requires an iPhone 15 Pro or newer. Use the Anthropic API below."
+        case .appleIntelligenceDisabled:
+            return "Open Settings → Apple Intelligence and enable it, then return here. The toggle is then live."
+        case .modelNotReady:
+            return "iOS is still downloading the Apple Intelligence model. Try again in a few minutes; the toggle will go live automatically."
+        case .unknown:
+            return "Apple Intelligence didn't report a known state. Falling back to the Anthropic API path."
+        }
+    }
+
+    private var canEnableLocal: Bool { AppleIntelligenceClient.isAvailable }
 
     var body: some View {
         List {
+            // Apple Intelligence (preferred when available)
+            Section {
+                Toggle("Use Apple Intelligence (on-device)", isOn: $settings.useAppleIntelligence)
+                    .disabled(!canEnableLocal)
+                LabeledContent("Status", value: availabilityLabel)
+            } header: {
+                Text("On-Device Curator")
+            } footer: {
+                Text(availabilityFooter)
+            }
+
+            // Anthropic API (used when local is off or unavailable)
             Section {
                 if revealKey {
                     TextField("sk-ant-…", text: $settings.apiKey)
@@ -29,30 +78,37 @@ struct AISettingsView: View {
                     }
                 }
             } header: {
-                Text("Anthropic API Key")
+                Text("Anthropic API Key (Cloud Fallback)")
             } footer: {
-                Text("Your key is stored only on this device (UserDefaults). Get a key from console.anthropic.com — small Smart Play calls run on Claude Haiku and are inexpensive.")
+                Text("Used when Apple Intelligence is unavailable or the toggle is off. Your key is stored only on this device. Get one from console.anthropic.com — Smart Play calls run on Claude Haiku and are inexpensive.")
             }
 
             Section {
-                LabeledContent("Status",
-                               value: settings.isConfigured ? "Configured" : "Not configured")
-                LabeledContent("Default model", value: AnthropicClient.defaultModel)
+                LabeledContent("Active backend", value: activeBackendLabel)
+                LabeledContent("Anthropic model", value: AnthropicClient.defaultModel)
             } header: {
                 Text("Status")
             }
 
             Section {
-                Text("**Vibe Match** — type a free-text vibe (e.g. ‟rainy afternoon”). Claude picks tracks from your library that fit.")
-                Text("**Storyteller** — Claude assembles a thematic 8-12 track narrative arc with a short blurb at the top of the queue.")
+                Text("**Vibe Match** — type a free-text vibe (e.g. ‟rainy afternoon”). The model picks tracks from your library that fit.")
+                Text("**Storyteller** — assembles a thematic 8-12 track narrative arc with a short blurb at the top of the queue.")
                 Text("**Sonic Contrast** — alternates between stylistically different tracks to keep the listener engaged.")
             } header: {
                 Text("AI Modes")
             } footer: {
-                Text("Each call sends a compact manifest of your library (title/artist/album/year/duration only — no audio) to Anthropic and receives an ordered list of stableIDs back.")
+                Text("Each call sends a compact manifest of your library (title/artist/album/year/duration — no audio). With Apple Intelligence on, the manifest stays on-device.")
             }
         }
         .navigationTitle("AI Smart Play")
         .navigationBarTitleDisplayMode(.inline)
+        .onAppear { availabilityRefreshTick &+= 1 }
+    }
+
+    private var activeBackendLabel: String {
+        if settings.useAppleIntelligence && AppleIntelligenceClient.isAvailable {
+            return "Apple Intelligence (on-device)"
+        }
+        return settings.apiKey.isEmpty ? "Not configured" : "Anthropic (cloud)"
     }
 }

--- a/TESTING.md
+++ b/TESTING.md
@@ -134,6 +134,14 @@ If a section is irrelevant to your PR (e.g. you only touched skin loading), stil
 - [ ] **Storyteller** / **Sonic Contrast**: tap → queue starts without a prompt; footer shows model-generated title + blurb.
 - [ ] Network error (airplane mode mid-call) surfaces as an alert; UI returns to idle.
 
+#### Apple Intelligence (on-device) backend
+
+- [ ] On a supported device (iPhone 15 Pro+ running iOS 26+, Apple Intelligence enabled): Settings → AI Smart Play → "On-Device Curator" status shows **Available**; toggle is on by default.
+- [ ] **Active backend** under Status reads "Apple Intelligence (on-device)" when the toggle is on.
+- [ ] Vibe Match with the toggle on: queue builds without any network traffic (verify by enabling airplane mode → it still works).
+- [ ] On an unsupported device or simulator: status reads **Not supported on this device** / **Requires iOS 26+** / **Disabled in Settings** as appropriate; toggle is disabled; activating an AI mode falls back to the Anthropic path.
+- [ ] Toggle off → backend flips to Anthropic; both still work as long as the key is present.
+
 ---
 
 ## I. Visualizer styles (SwiftUI player)


### PR DESCRIPTION
## Summary
Adds a second backend for AI Smart Play (issue #25) that runs entirely on the device using the **Foundation Models framework** (iOS 26+, iPhone 15 Pro and newer). When available, it's preferred over the Anthropic API: free, private, no key required, no network egress.

## What changes
| File | Purpose |
|---|---|
| `HarmonIQ/Player/AppleIntelligenceClient.swift` | New. Wraps `LanguageModelSession` with the same `send(systemPrompt:userPrompt:)` shape as `AnthropicClient`. Fine-grained availability enum (requiresOSUpdate / deviceNotEligible / appleIntelligenceDisabled / modelNotReady) feeds the Settings status row. All call sites gated with `@available(iOS 26.0, *)` + `#if canImport(FoundationModels)` so the project still compiles on older toolchains. |
| `HarmonIQ/Player/AnthropicClient.swift` | `AnthropicSettings` gains `useAppleIntelligence: Bool` (default ON). `isConfigured` returns true when *either* backend is usable. |
| `HarmonIQ/Player/SmartPlayAI.swift` | `curate()` picks a backend on the main actor up-front, then drops into the actor-free pipeline. On-device when toggle is on AND `AppleIntelligenceClient.isAvailable`; otherwise Anthropic. |
| `HarmonIQ/Views/AISettingsView.swift` | Reorganized: On-Device Curator at top with status row + context-aware footer, then Anthropic key as cloud fallback, then Status section showing the currently-active backend. |
| `TESTING.md` | New checklist subsection for the on-device path. |

## Backend dispatch
```
toggle ON  + AppleIntelligence available  → Foundation Models (on-device)
toggle ON  + unavailable on this device   → Anthropic (if key present)
toggle OFF                                 → Anthropic (if key present)
no AI configured                           → AI Smart Play rows are disabled
```

The user-facing Vibe Match / Storyteller / Sonic Contrast flows are identical between backends — same prompt structure, same JSON parser. Only the transport changes.

Refs #25.

## Test plan
- [x] Build green on iPhone 17 sim. App cold-launches.
- [ ] On iPhone 15 Pro+ running iOS 26+ with Apple Intelligence enabled: Settings → AI Smart Play → "On-Device Curator" reads **Available**; toggle is on by default.
- [ ] Active-backend label switches between "Apple Intelligence (on-device)" and "Anthropic (cloud)" as the toggle flips.
- [ ] Vibe Match with toggle on + airplane mode: queue still builds (proves on-device).
- [ ] Unsupported device / simulator: status shows the right message; toggle is disabled; activating an AI mode falls back to Anthropic.
- [ ] No regression in the existing Anthropic flow.

## Notes for review
- The iPhone simulator typically reports the on-device LLM as unavailable (Apple Intelligence is restricted to real hardware). The toggle will be disabled in the sim — verify on a real iPhone 15 Pro / 16 Pro / 17 Pro.
- `LanguageModelSession.respond(to:)` returns plain text; we keep the same JSON-from-text parsing the Anthropic path uses, so prompt updates apply uniformly.
- Switching to `@Generable` structured output is a follow-up — gives stronger guarantees but locks the codebase tighter to iOS 26 surface area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
