### PR TITLE
Save AI-curated SmartPlay queues as playlists (closes #58)

### DIFF
--- a/HarmonIQ/Models/Playlist.swift
+++ b/HarmonIQ/Models/Playlist.swift
@@ -12,6 +12,14 @@ struct Playlist: Identifiable, Hashable {
     /// True when this is the drive's system "Favorites" playlist. Each drive has
     /// at most one. Persisted to the drive (so all devices see the same set).
     var isFavorites: Bool
+    /// True when this playlist was saved from an AI Smart Play queue. Persisted.
+    var isSmart: Bool
+    /// The user's original prompt (for Vibe Match), or nil for non-prompt
+    /// modes / non-AI playlists. Persisted so the row can show what was typed.
+    var smartPrompt: String?
+    /// The `SmartPlayMode.rawValue` used to generate this queue, if any.
+    /// Stored so a future "regenerate" action can rebuild it. Persisted.
+    var smartMode: String?
 
     init(id: UUID = UUID(),
          name: String,
@@ -19,7 +27,10 @@ struct Playlist: Identifiable, Hashable {
          createdAt: Date = Date(),
          updatedAt: Date = Date(),
          rootBookmarkID: UUID,
-         isFavorites: Bool = false) {
+         isFavorites: Bool = false,
+         isSmart: Bool = false,
+         smartPrompt: String? = nil,
+         smartMode: String? = nil) {
         self.id = id
         self.name = name
         self.trackIDs = trackIDs
@@ -27,6 +38,9 @@ struct Playlist: Identifiable, Hashable {
         self.updatedAt = updatedAt
         self.rootBookmarkID = rootBookmarkID
         self.isFavorites = isFavorites
+        self.isSmart = isSmart
+        self.smartPrompt = smartPrompt
+        self.smartMode = smartMode
     }
 }
 

--- a/HarmonIQ/Persistence/DriveLibraryStore.swift
+++ b/HarmonIQ/Persistence/DriveLibraryStore.swift
@@ -53,10 +53,16 @@ enum DriveLibraryStore {
         var trackIDs: [String]
         var createdAt: Date
         var updatedAt: Date
-        /// Optional kind tag. `"favorites"` marks the drive's system Favorites
-        /// playlist; nil/missing means a normal user playlist. Optional so
-        /// existing playlists.json files (no `kind` field) decode unchanged.
+        /// Optional kind tag.
+        ///   `"favorites"` — the drive's system Favorites playlist.
+        ///   `"smart"`     — saved from an AI Smart Play queue (issue #58).
+        ///   nil / missing — a normal hand-built playlist.
+        /// Optional so existing playlists.json files decode unchanged.
         var kind: String?
+        /// Original user prompt for AI-curated playlists (issue #58). Optional.
+        var smartPrompt: String?
+        /// `SmartPlayMode.rawValue` used to generate this AI-curated queue. Optional.
+        var smartMode: String?
     }
 
     // MARK: - Paths
@@ -167,6 +173,7 @@ enum DriveLibraryStore {
     }
 
     static let favoritesKind = "favorites"
+    static let smartKind = "smart"
 
     static func toPlaylist(_ dp: DrivePlaylist, rootBookmarkID: UUID) -> Playlist {
         Playlist(
@@ -176,18 +183,27 @@ enum DriveLibraryStore {
             createdAt: dp.createdAt,
             updatedAt: dp.updatedAt,
             rootBookmarkID: rootBookmarkID,
-            isFavorites: dp.kind == favoritesKind
+            isFavorites: dp.kind == favoritesKind,
+            isSmart: dp.kind == smartKind,
+            smartPrompt: dp.smartPrompt,
+            smartMode: dp.smartMode
         )
     }
 
     static func fromPlaylist(_ p: Playlist) -> DrivePlaylist {
-        DrivePlaylist(
+        let kind: String?
+        if p.isFavorites { kind = favoritesKind }
+        else if p.isSmart { kind = smartKind }
+        else { kind = nil }
+        return DrivePlaylist(
             id: p.id,
             name: p.name,
             trackIDs: p.trackIDs,
             createdAt: p.createdAt,
             updatedAt: p.updatedAt,
-            kind: p.isFavorites ? favoritesKind : nil
+            kind: kind,
+            smartPrompt: p.isSmart ? p.smartPrompt : nil,
+            smartMode: p.isSmart ? p.smartMode : nil
         )
     }
 

--- a/HarmonIQ/Persistence/LibraryStore.swift
+++ b/HarmonIQ/Persistence/LibraryStore.swift
@@ -292,6 +292,67 @@ final class LibraryStore: ObservableObject {
         return playlist.trackIDs.compactMap { map[$0] }
     }
 
+    // MARK: - Smart playlists (issue #58)
+
+    struct SmartSaveResult {
+        let playlist: Playlist
+        let savedCount: Int
+        let totalCount: Int
+        var partial: Bool { savedCount < totalCount }
+    }
+
+    /// Save an AI-curated queue as a regular drive-resident playlist.
+    /// `trackIDs` is the ordered queue. `prompt`/`mode` are stashed on the
+    /// playlist so the row can show what was typed and a future Regenerate
+    /// action can rebuild it.
+    ///
+    /// Owning drive: the drive that contains the most tracks from the
+    /// queue (playlists own exactly one drive). Tracks on other drives
+    /// are dropped from the saved playlist; the result reports the
+    /// `savedCount` so the UI can show "Saved N of M tracks".
+    @discardableResult
+    func saveSmartPlaylist(name: String,
+                           trackIDs: [String],
+                           prompt: String?,
+                           mode: String?) -> SmartSaveResult? {
+        guard !trackIDs.isEmpty else { return nil }
+        // Map each queue track to its owning drive so we can count.
+        let trackByID: [String: Track] = Dictionary(uniqueKeysWithValues: tracks.map { ($0.stableID, $0) })
+        var dropPerRoot: [UUID: [String]] = [:]
+        for tid in trackIDs {
+            guard let t = trackByID[tid] else { continue }
+            dropPerRoot[t.rootBookmarkID, default: []].append(tid)
+        }
+        // Pick the drive holding the most queue tracks. Tiebreaker: first
+        // mounted drive that has a positive count, in `roots` order.
+        let chosen: UUID? = roots
+            .map { ($0.id, dropPerRoot[$0.id]?.count ?? 0) }
+            .filter { $0.1 > 0 }
+            .max(by: { $0.1 < $1.1 })?.0
+        guard let target = chosen else { return nil }
+        let kept = dropPerRoot[target] ?? []
+        // Preserve the original queue order while filtering to the chosen drive.
+        let keptSet = Set(kept)
+        let orderedKept = trackIDs.filter { keptSet.contains($0) }
+        let p = Playlist(
+            name: name,
+            trackIDs: orderedKept,
+            rootBookmarkID: target,
+            isSmart: true,
+            smartPrompt: prompt,
+            smartMode: mode
+        )
+        playlists.append(p)
+        writePlaylistsToDrive(rootID: target)
+        return SmartSaveResult(playlist: p, savedCount: orderedKept.count, totalCount: trackIDs.count)
+    }
+
+    /// All AI-saved playlists, ordered by `createdAt` descending.
+    var smartPlaylists: [Playlist] {
+        playlists.filter { $0.isSmart }
+            .sorted { $0.createdAt > $1.createdAt }
+    }
+
     // MARK: - Favorites
 
     /// Per-drive system Favorites playlist, if one exists for the given drive.

--- a/HarmonIQ/Player/AudioPlayerManager.swift
+++ b/HarmonIQ/Player/AudioPlayerManager.swift
@@ -258,7 +258,11 @@ final class AudioPlayerManager: NSObject, ObservableObject {
         guard !resolved.isEmpty else { return }
         activeSmartMode = mode
         isShuffleEnabled = false
-        aiAnnotation = AIQueueAnnotation(title: curated.title, blurb: curated.blurb, rationales: curated.rationales)
+        aiAnnotation = AIQueueAnnotation(title: curated.title,
+                                         blurb: curated.blurb,
+                                         rationales: curated.rationales,
+                                         prompt: userPrompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : userPrompt,
+                                         mode: mode.rawValue)
         loadQueue(resolved, startIndex: 0)
         playCurrent()
         presentNowPlayingTick &+= 1
@@ -668,6 +672,10 @@ struct AIQueueAnnotation: Equatable {
     let blurb: String
     /// One-line rationale per stableID, when the model provided one.
     let rationales: [String: String]
+    /// User's free-text prompt for prompt-driven modes (Vibe Match), or nil.
+    let prompt: String?
+    /// `SmartPlayMode.rawValue` that produced this queue.
+    let mode: String?
 }
 
 // MARK: - Meter sink

--- a/HarmonIQ/Views/NowPlayingView.swift
+++ b/HarmonIQ/Views/NowPlayingView.swift
@@ -7,6 +7,11 @@ struct NowPlayingView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var seekingValue: Double?
     @State private var showSkinPicker = false
+    // Save AI-curated queue as a playlist (issue #58).
+    @State private var showSavePrompt = false
+    @State private var savePlaylistName = ""
+    @State private var saveToast: String?
+    @State private var saveToastUntil = Date.distantPast
 
     var body: some View {
         ZStack {
@@ -183,15 +188,95 @@ struct NowPlayingView: View {
                     .lcdReadout(corner: 3)
                     .padding(.bottom, 8)
                 }
+
+                if player.aiAnnotation != nil {
+                    Button {
+                        savePlaylistName = defaultSaveName(annotation: player.aiAnnotation)
+                        showSavePrompt = true
+                    } label: {
+                        Label("Save as Playlist", systemImage: "square.and.arrow.down")
+                            .font(.caption.bold())
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 6)
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(WinampTheme.lcdGlow)
+                    .padding(.bottom, 8)
+                }
             }
             .padding(.bottom, 24)
+            .overlay(alignment: .top) { saveToastView }
         }
         .sheet(isPresented: $showSkinPicker) {
             SkinPickerSheet()
                 .environmentObject(skinManager)
         }
+        .alert("Save Smart Play Queue", isPresented: $showSavePrompt) {
+            TextField("Name", text: $savePlaylistName)
+            Button("Save") {
+                let trimmed = savePlaylistName.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !trimmed.isEmpty else { return }
+                performSave(name: trimmed)
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Saves the current AI-curated queue as a regular playlist on the drive that owns most of the tracks.")
+        }
         .onAppear  { player.setVisualizerActive(true)  }
         .onDisappear { player.setVisualizerActive(false) }
+    }
+
+    @ViewBuilder
+    private var saveToastView: some View {
+        TimelineView(.animation(minimumInterval: 1.0 / 10.0)) { timeline in
+            let remaining = saveToastUntil.timeIntervalSince(timeline.date)
+            if remaining > 0, let msg = saveToast {
+                Text(msg)
+                    .font(WinampTheme.lcdFont(size: 12))
+                    .foregroundStyle(WinampTheme.lcdGlow)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 8)
+                    .background(WinampTheme.lcdBackground.opacity(0.9))
+                    .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(WinampTheme.lcdGlow.opacity(0.6)))
+                    .clipShape(RoundedRectangle(cornerRadius: 4))
+                    .padding(.top, 60)
+                    .opacity(min(1.0, remaining / 0.4))
+                    .transition(.opacity)
+            }
+        }
+    }
+
+    private func performSave(name: String) {
+        guard let annotation = player.aiAnnotation else { return }
+        let queueIDs = player.queue.map { $0.stableID }
+        let result = library.saveSmartPlaylist(
+            name: name,
+            trackIDs: queueIDs,
+            prompt: annotation.prompt,
+            mode: annotation.mode
+        )
+        if let result = result {
+            saveToast = result.partial
+                ? "Saved \(result.savedCount) of \(result.totalCount) tracks"
+                : "Saved \(result.savedCount) tracks"
+        } else {
+            saveToast = "Couldn't save — no drive contains the queue"
+        }
+        saveToastUntil = Date().addingTimeInterval(2.0)
+    }
+
+    private func defaultSaveName(annotation: AIQueueAnnotation?) -> String {
+        if let prompt = annotation?.prompt?.trimmingCharacters(in: .whitespacesAndNewlines), !prompt.isEmpty {
+            // Capitalize first character; truncate to ~40 chars.
+            let titled = prompt.prefix(1).uppercased() + prompt.dropFirst()
+            return String(titled.prefix(40))
+        }
+        if let title = annotation?.title, !title.isEmpty {
+            return String(title.prefix(40))
+        }
+        let df = DateFormatter()
+        df.dateFormat = "yyyy-MM-dd"
+        return "Smart Mix — \(df.string(from: Date()))"
     }
 
     private var repeatIconName: String {

--- a/HarmonIQ/Views/PlaylistsView.swift
+++ b/HarmonIQ/Views/PlaylistsView.swift
@@ -7,7 +7,10 @@ struct PlaylistsView: View {
     @State private var showNoDriveAlert = false
 
     private var favorites: [Playlist] { library.favoritesPlaylists }
-    private var userPlaylists: [Playlist] { library.playlists.filter { !$0.isFavorites } }
+    private var smartPlaylists: [Playlist] { library.smartPlaylists }
+    private var userPlaylists: [Playlist] {
+        library.playlists.filter { !$0.isFavorites && !$0.isSmart }
+    }
     private var driveName: [UUID: String] {
         Dictionary(uniqueKeysWithValues: library.roots.map { ($0.id, $0.displayName) })
     }
@@ -47,6 +50,38 @@ struct PlaylistsView: View {
                                     }
                                 }
                             }
+                        }
+                    }
+
+                    if !smartPlaylists.isEmpty {
+                        Section {
+                            ForEach(smartPlaylists) { playlist in
+                                NavigationLink {
+                                    PlaylistDetailView(playlist: playlist)
+                                } label: {
+                                    HStack(spacing: 12) {
+                                        Image(systemName: "wand.and.stars")
+                                            .font(.title3)
+                                            .foregroundStyle(.purple)
+                                            .frame(width: 36, height: 36)
+                                            .background(Color.purple.opacity(0.15), in: RoundedRectangle(cornerRadius: 8))
+                                        VStack(alignment: .leading, spacing: 2) {
+                                            Text(playlist.name)
+                                            if let prompt = playlist.smartPrompt, !prompt.isEmpty {
+                                                Text("\u{201C}\(prompt)\u{201D} · \(playlist.trackIDs.count) tracks")
+                                                    .font(.caption).foregroundStyle(.secondary)
+                                                    .lineLimit(1)
+                                            } else {
+                                                Text("\(playlist.trackIDs.count) tracks").font(.caption).foregroundStyle(.secondary)
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            .onDelete(perform: deleteSmartPlaylist)
+                        } header: {
+                            Label("AI-Curated", systemImage: "sparkles")
+                                .font(.caption.bold())
                         }
                     }
 
@@ -108,6 +143,13 @@ struct PlaylistsView: View {
 
     private func deleteUserPlaylist(at offsets: IndexSet) {
         let snapshot = userPlaylists
+        for idx in offsets where snapshot.indices.contains(idx) {
+            library.deletePlaylist(snapshot[idx])
+        }
+    }
+
+    private func deleteSmartPlaylist(at offsets: IndexSet) {
+        let snapshot = smartPlaylists
         for idx in offsets where snapshot.indices.contains(idx) {
             library.deletePlaylist(snapshot[idx])
         }

--- a/TESTING.md
+++ b/TESTING.md
@@ -96,6 +96,10 @@ If a section is irrelevant to your PR (e.g. you only touched skin loading), stil
 - [ ] Unfavorite from the player → heart unfills, count in Favorites decrements; if it was the last track the Favorites row remains (auto-managed) but shows `0 tracks`.
 - [ ] Quit + relaunch → favorite state survives; the on-drive `playlists.json` includes `"kind": "favorites"` for the system playlist.
 - [ ] With 2+ drives mounted, favorite tracks from each → two Favorites rows appear, each labelled with its drive name.
+- [ ] After running Vibe Match (or Storyteller / Sonic Contrast), the Now Playing screen shows a **Save as Playlist** button below the SMART PLAY pill. Tap → alert pre-fills with the prompt as the name; saving produces a row in the Playlists tab under an **AI-Curated** section with a sparkles icon and the prompt as subtitle.
+- [ ] Saved smart playlist plays the same tracks in the same order on relaunch.
+- [ ] Cross-drive queue: the playlist owns the drive that holds the most tracks; "Saved N of M tracks" toast appears when not all tracks are kept.
+- [ ] Existing `playlists.json` files (no `smartPrompt`/`smartMode` fields) still decode without errors.
 
 ---
 


### PR DESCRIPTION
## Summary
Vibe Match / Storyteller / Sonic Contrast queues used to be ephemeral — walk away and the curation is gone. This adds a **Save as Playlist** button to Now Playing that pops while an AI annotation is active. Tapping prompts for a name (pre-filled with the user's vibe prompt, capitalized + truncated to 40 chars) and persists the queue as a regular drive-resident playlist that survives relaunch and rides along with the drive across devices.

## Schema (all backward-compatible)
| Field | Where | What |
|---|---|---|
| `isSmart: Bool` | `Playlist` | True when saved from an AI queue. |
| `smartPrompt: String?` | `Playlist` / `DrivePlaylist` | The user's free-text prompt (Vibe Match). |
| `smartMode: String?` | `Playlist` / `DrivePlaylist` | `SmartPlayMode.rawValue` — for a future Regenerate action. |
| `kind = "smart"` | `DrivePlaylist` | Joins the existing `"favorites"` value. |

`AIQueueAnnotation` gains `prompt` + `mode` so the Save flow has what it needs.

## Saving across drives
Playlists own exactly one drive. The save picks the drive holding the **most** queue tracks; tracks on other drives are dropped, and the toast reads "Saved N of M tracks" when the count diverges.

## UI changes
- **Now Playing** — bordered "Save as Playlist" button below the SMART PLAY pill (visible only when `aiAnnotation != nil`). LCD-styled toast shows the save result.
- **Playlists tab** — new **AI-Curated** section above user playlists, each row with a `wand.and.stars` icon and the original prompt as subtitle. Swipe-to-delete supported.

Closes #58.

## Test plan
- [x] Build green on iPhone 17 sim. App cold-launches.
- [ ] After running Vibe Match: Save as Playlist appears → alert pre-fills with the prompt → save → row appears under "AI-Curated" with the prompt as subtitle.
- [ ] Saved playlist plays the same tracks in the same order on relaunch.
- [ ] Cross-drive: the playlist owns the most-tracks drive; "Saved N of M tracks" toast on partial save.
- [ ] Existing `playlists.json` (without the new fields) loads unchanged.
- [ ] Storyteller / Sonic Contrast (no user prompt) — name defaults to the model's title, then a `Smart Mix — yyyy-MM-dd` fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
