### PR TITLE
Settings → Feedback section: file issues, star repo (closes #59)

### DIFF
--- a/HarmonIQ/Views/SettingsView.swift
+++ b/HarmonIQ/Views/SettingsView.swift
@@ -1,6 +1,18 @@
 import SwiftUI
 import UniformTypeIdentifiers
 
+/// Canonical feedback URLs for the GitHub repo. Linked from Settings → Feedback
+/// (issue #59). The new-issue URLs include a `labels=...` query so the GitHub
+/// form opens with the right label pre-selected; the optional `template=` query
+/// is harmless when the repo doesn't have an issue template (GitHub falls back
+/// to a blank issue with the label set).
+private enum FeedbackURL {
+    static let repo = URL(string: "https://github.com/LeoHChen/HarmonIQ")!
+    static let issues = URL(string: "https://github.com/LeoHChen/HarmonIQ/issues")!
+    static let featureRequest = URL(string: "https://github.com/LeoHChen/HarmonIQ/issues/new?labels=enhancement&template=feature_request.md")!
+    static let bugReport = URL(string: "https://github.com/LeoHChen/HarmonIQ/issues/new?labels=bug&template=bug_report.md")!
+}
+
 struct SettingsView: View {
     @EnvironmentObject var library: LibraryStore
     @EnvironmentObject var indexer: MusicIndexer
@@ -67,6 +79,30 @@ struct SettingsView: View {
                 Text("AI")
             } footer: {
                 Text("Optional — adds AI-driven Smart Play modes (Vibe Match, Storyteller, Sonic Contrast). Bring your own Anthropic API key. Calls are billed to your account.")
+            }
+
+            Section {
+                Link(destination: FeedbackURL.featureRequest) {
+                    Label("Request a feature", systemImage: "lightbulb")
+                }
+                Link(destination: FeedbackURL.bugReport) {
+                    Label("Report a bug", systemImage: "ladybug")
+                }
+                Link(destination: FeedbackURL.issues) {
+                    Label("Browse open issues", systemImage: "bubble.left.and.bubble.right")
+                }
+                Link(destination: FeedbackURL.repo) {
+                    Label("Star on GitHub", systemImage: "star")
+                }
+                Button {
+                    UIPasteboard.general.string = BuildInfo.clipboardSummary
+                } label: {
+                    Label("Copy build info", systemImage: "doc.on.clipboard")
+                }
+            } header: {
+                Text("Feedback")
+            } footer: {
+                Text("Tip: tap “Copy build info” before “Report a bug” — paste it into the issue so we can triage faster.")
             }
 
             Section {

--- a/TESTING.md
+++ b/TESTING.md
@@ -26,6 +26,7 @@ If a section is irrelevant to your PR (e.g. you only touched skin loading), stil
 - [ ] Launch screen renders the branded gradient + vinyl disc, not a flat-color flash.
 - [ ] `git status` is clean (no accidental file leaks like `.DS_Store`, build artifacts).
 - [ ] Settings → About shows real Version, Build, Commit (short SHA), Release tag, and Built-at — not hard-coded `1.0`. "Copy build info" puts a multi-line block on the clipboard.
+- [ ] Settings → Feedback section opens GitHub correctly (Request a feature → enhancement-labeled new issue, Report a bug → bug-labeled new issue, Browse open issues → /issues, Star on GitHub → repo); Copy build info pastes a multi-line block.
 
 ---
 


### PR DESCRIPTION
## Summary
Adds an in-app path to GitHub from Settings, just above About:

- Request a feature → `/issues/new?labels=enhancement&template=feature_request.md`
- Report a bug → `/issues/new?labels=bug&template=bug_report.md`
- Browse open issues → `/issues`
- Star on GitHub → repo home
- Copy build info → reuses `BuildInfo.clipboardSummary` from #52

The label query parameters mean the GitHub new-issue form opens with the right label pre-set; the `template=` query is harmless if the repo doesn't yet have those template files.

Pairing 'Copy build info' with 'Report a bug' is the load-bearing combo — TestFlight users now have one-tap path to a triageable report.

Closes #59.

## Test plan
- [x] Build green on iPhone 17 sim.
- [ ] Each link opens Safari (or GitHub app) at the expected URL with labels pre-set.
- [ ] Copy build info writes the multi-line version/build/commit/tag/built-at block to the clipboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)