### PR TITLE
Indexer: skip work when drive is unchanged; incremental otherwise (closes #55)

### DIFF
--- a/HarmonIQ/Indexer/MusicIndexer.swift
+++ b/HarmonIQ/Indexer/MusicIndexer.swift
@@ -31,15 +31,25 @@ final class MusicIndexer: ObservableObject {
 
         let bookmark = root.bookmark
         let rootID = root.id
+        let priorFingerprint = root.lastScanFingerprint
         let localCacheDir = LibraryStore.shared.artworkDirectory
+        let priorTracks = LibraryStore.shared.tracks.filter { $0.rootBookmarkID == rootID }
 
         indexingTask = Task.detached(priority: .userInitiated) {
-            await Self.runIndex(rootID: rootID, bookmark: bookmark, localCacheDir: localCacheDir)
+            await Self.runIndex(rootID: rootID,
+                                bookmark: bookmark,
+                                priorFingerprint: priorFingerprint,
+                                priorTracks: priorTracks,
+                                localCacheDir: localCacheDir)
         }
     }
 
     /// Heavy lifting runs off the main actor. UI updates hop back via MainActor.run.
-    private static func runIndex(rootID: UUID, bookmark: Data, localCacheDir: URL) async {
+    private static func runIndex(rootID: UUID,
+                                 bookmark: Data,
+                                 priorFingerprint: ScanFingerprint?,
+                                 priorTracks: [Track],
+                                 localCacheDir: URL) async {
         await MainActor.run {
             MusicIndexer.shared.statusMessage = "Resolving access to drive…"
         }
@@ -58,6 +68,24 @@ final class MusicIndexer: ObservableObject {
 
         let started = resolvedURL.startAccessingSecurityScopedResource()
         defer { if started { resolvedURL.stopAccessingSecurityScopedResource() } }
+
+        // Cheap top-level fingerprint check. If the drive root's mtime AND
+        // child count both match the last scan, declare "Up to date" and
+        // skip the walk. Caveat: in-place file edits (tag changes without
+        // rename) don't bump folder mtime, so a user who edits tags and
+        // immediately reindexes might see "Up to date" — they can hit
+        // Reindex again later, or add/remove any file at the root to
+        // invalidate the fingerprint. (Issue #55, acceptable tradeoff.)
+        if let fingerprint = priorFingerprint,
+           let current = computeFingerprint(rootURL: resolvedURL),
+           current == fingerprint {
+            await MainActor.run {
+                MusicIndexer.shared.isIndexing = false
+                MusicIndexer.shared.progress = 1
+                MusicIndexer.shared.statusMessage = "Up to date — \(priorTracks.count) tracks."
+            }
+            return
+        }
 
         // Try to create the on-drive HarmonIQ/ folder. If the picker handed us
         // a read-only location (iOS system "Music", certain iCloud paths) the
@@ -98,30 +126,58 @@ final class MusicIndexer: ObservableObject {
                 MusicIndexer.shared.progress = 1
                 MusicIndexer.shared.statusMessage = "No audio files found on this drive."
                 LibraryStore.shared.replaceTracks(forRoot: rootID, with: [])
-                if stale, var root = LibraryStore.shared.roots.first(where: { $0.id == rootID }) {
-                    if let newBookmark = try? resolvedURL.bookmarkData(options: [], includingResourceValuesForKeys: nil, relativeTo: nil) {
-                        root.bookmark = newBookmark
-                        LibraryStore.shared.updateRoot(root)
-                    }
-                }
+                writebackFingerprint(rootID: rootID, rootURL: resolvedURL, stale: stale)
             }
             return
         }
+
+        // Build the prior-tracks lookup once. Stored Track rows are keyed by
+        // stableID (sha1 of relative path).
+        let priorByID: [String: Track] = Dictionary(uniqueKeysWithValues: priorTracks.map { ($0.stableID, $0) })
 
         var tracks: [Track] = []
         tracks.reserveCapacity(urls.count)
         let rootPathComponents = resolvedURL.pathComponents
         var seenArtworkKeys: Set<String> = []
+        var added = 0
+        var updated = 0
+        var unchanged = 0
 
         for (idx, url) in urls.enumerated() {
             if Task.isCancelled { break }
 
             let relComponents = relativePathComponents(of: url, fromRoot: rootPathComponents)
             let stableID = stableIdentifier(for: relComponents)
-            let attrs = try? FileManager.default.attributesOfItem(atPath: url.path)
-            let fileSize = (attrs?[.size] as? NSNumber)?.int64Value ?? 0
+            let resourceValues = try? url.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey])
+            let mtime = resourceValues?.contentModificationDate
+            let fileSize = Int64((resourceValues?.fileSize) ?? 0)
             let fileFormat = url.pathExtension.lowercased()
 
+            // Reuse path: existing row whose stored mtime matches the file's
+            // current mtime. Saves the metadata-extraction + artwork-hash
+            // round trip — the most expensive per-file work in this loop.
+            if let existing = priorByID[stableID],
+               let storedMtime = existing.fileModified,
+               let mtime = mtime,
+               abs(storedMtime.timeIntervalSince(mtime)) < 1 {
+                tracks.append(existing)
+                unchanged += 1
+                if let path = existing.artworkPath {
+                    seenArtworkKeys.insert((path as NSString).deletingPathExtension)
+                }
+                let processed = idx + 1
+                if processed % 25 == 0 || processed == urls.count {
+                    await MainActor.run {
+                        MusicIndexer.shared.processed = processed
+                        MusicIndexer.shared.totalToProcess = urls.count
+                        MusicIndexer.shared.progress = Double(processed) / Double(urls.count)
+                        MusicIndexer.shared.statusMessage = "Scanning — \(processed)/\(urls.count)"
+                    }
+                }
+                continue
+            }
+
+            // Either new (no prior row) or mtime changed → re-extract.
             let metadata = await MetadataExtractor.extract(from: url)
 
             var artworkPath: String? = nil
@@ -130,7 +186,6 @@ final class MusicIndexer: ObservableObject {
                 let hash = sha1Hex(albumKey)
                 let localTarget = localCacheDir.appendingPathComponent("\(hash).jpg")
                 if isReadOnly {
-                    // No on-drive Artwork folder — write straight to local cache.
                     if seenArtworkKeys.contains(hash) || FileManager.default.fileExists(atPath: localTarget.path) {
                         artworkPath = "\(hash).jpg"
                         seenArtworkKeys.insert(hash)
@@ -143,14 +198,12 @@ final class MusicIndexer: ObservableObject {
                     if seenArtworkKeys.contains(hash) || FileManager.default.fileExists(atPath: driveTarget.path) {
                         artworkPath = "\(hash).jpg"
                         seenArtworkKeys.insert(hash)
-                        // Best-effort mirror to local cache if it doesn't already exist there.
                         if !FileManager.default.fileExists(atPath: localTarget.path) {
                             try? FileManager.default.copyItem(at: driveTarget, to: localTarget)
                         }
                     } else if let saved = await MetadataExtractor.saveArtworkAsync(data, named: hash, to: driveArtworkDir) {
                         artworkPath = saved
                         seenArtworkKeys.insert(hash)
-                        // Mirror the freshly written jpeg into the local cache.
                         if !FileManager.default.fileExists(atPath: localTarget.path) {
                             try? FileManager.default.copyItem(at: driveTarget, to: localTarget)
                         }
@@ -176,36 +229,71 @@ final class MusicIndexer: ObservableObject {
                 duration: metadata.duration,
                 fileSize: fileSize,
                 fileFormat: fileFormat,
-                artworkPath: artworkPath
+                artworkPath: artworkPath,
+                fileModified: mtime
             )
             tracks.append(track)
+            if priorByID[stableID] == nil { added += 1 } else { updated += 1 }
 
             let processed = idx + 1
-            let total = urls.count
-            if processed % 5 == 0 || processed == total {
+            if processed % 5 == 0 || processed == urls.count {
                 await MainActor.run {
                     MusicIndexer.shared.processed = processed
-                    MusicIndexer.shared.totalToProcess = total
-                    MusicIndexer.shared.progress = total > 0 ? Double(processed) / Double(total) : 1
-                    MusicIndexer.shared.statusMessage = "Indexed \(processed) of \(total)"
+                    MusicIndexer.shared.totalToProcess = urls.count
+                    MusicIndexer.shared.progress = Double(processed) / Double(urls.count)
+                    MusicIndexer.shared.statusMessage = "Indexed \(processed) of \(urls.count)"
                 }
             }
         }
 
+        let removed = max(0, priorTracks.count - unchanged - updated)
         let collected = tracks
+        let summaryAdded = added
+        let summaryUpdated = updated
+        let summaryRemoved = removed
         await MainActor.run {
             // replaceTracks writes the on-drive library.json itself.
             LibraryStore.shared.replaceTracks(forRoot: rootID, with: collected)
-            if stale, var root = LibraryStore.shared.roots.first(where: { $0.id == rootID }) {
-                if let newBookmark = try? resolvedURL.bookmarkData(options: [], includingResourceValuesForKeys: nil, relativeTo: nil) {
-                    root.bookmark = newBookmark
-                    LibraryStore.shared.updateRoot(root)
-                }
-            }
+            writebackFingerprint(rootID: rootID, rootURL: resolvedURL, stale: stale)
             MusicIndexer.shared.isIndexing = false
             MusicIndexer.shared.progress = 1
-            MusicIndexer.shared.statusMessage = "Indexed \(collected.count) tracks."
+            if summaryAdded == 0 && summaryUpdated == 0 && summaryRemoved == 0 {
+                MusicIndexer.shared.statusMessage = "Up to date — \(collected.count) tracks."
+            } else {
+                var parts: [String] = []
+                if summaryAdded > 0 { parts.append("\(summaryAdded) new") }
+                if summaryUpdated > 0 { parts.append("\(summaryUpdated) updated") }
+                if summaryRemoved > 0 { parts.append("\(summaryRemoved) removed") }
+                MusicIndexer.shared.statusMessage = "Indexed \(collected.count) tracks (\(parts.joined(separator: ", "))).";
+            }
         }
+    }
+
+    /// Persist the new fingerprint + bookmark on the LibraryRoot. Run on
+    /// the main actor (needs LibraryStore).
+    @MainActor
+    private static func writebackFingerprint(rootID: UUID, rootURL: URL, stale: Bool) {
+        guard var root = LibraryStore.shared.roots.first(where: { $0.id == rootID }) else { return }
+        if stale, let newBookmark = try? rootURL.bookmarkData(options: [], includingResourceValuesForKeys: nil, relativeTo: nil) {
+            root.bookmark = newBookmark
+        }
+        if let fp = computeFingerprint(rootURL: rootURL) {
+            root.lastScanFingerprint = fp
+        }
+        LibraryStore.shared.updateRoot(root)
+    }
+
+    /// Cheap fingerprint: drive root's mtime + immediate-child count.
+    /// Returns nil when the FS metadata can't be read.
+    nonisolated private static func computeFingerprint(rootURL: URL) -> ScanFingerprint? {
+        let fm = FileManager.default
+        let rootValues = try? rootURL.resourceValues(forKeys: [.contentModificationDateKey])
+        guard let mtime = rootValues?.contentModificationDate else { return nil }
+        let children = (try? fm.contentsOfDirectory(at: rootURL, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])) ?? []
+        // Exclude HarmonIQ's own folder so writing the artwork cache doesn't
+        // invalidate the fingerprint.
+        let count = children.filter { $0.lastPathComponent != DriveLibraryStore.folderName }.count
+        return ScanFingerprint(rootMtime: mtime, childCount: count)
     }
 
     // MARK: - File walking (nonisolated helpers)

--- a/HarmonIQ/Models/Playlist.swift
+++ b/HarmonIQ/Models/Playlist.swift
@@ -44,6 +44,15 @@ struct Playlist: Identifiable, Hashable {
     }
 }
 
+/// Cheap-check baseline used by the incremental indexer (issue #55). When
+/// the drive root's mtime + immediate-child count match the stored
+/// fingerprint, a Reindex is a near-instant no-op. Optional / Codable so
+/// existing `roots.json` files migrate transparently.
+struct ScanFingerprint: Codable, Hashable {
+    var rootMtime: Date
+    var childCount: Int
+}
+
 struct LibraryRoot: Identifiable, Codable, Hashable {
     let id: UUID
     var displayName: String
@@ -55,18 +64,30 @@ struct LibraryRoot: Identifiable, Codable, Hashable {
     /// read-only root live in the app sandbox via SandboxRootStore instead of
     /// in the on-drive HarmonIQ/ folder.
     var isReadOnly: Bool
+    /// Snapshot of the root's mtime + immediate-child count at the end of
+    /// the last scan. Used by the cheap-check to skip walking when the
+    /// drive's top-level layout is unchanged. nil → cheap check is
+    /// skipped (next scan walks unconditionally and populates).
+    var lastScanFingerprint: ScanFingerprint?
 
-    init(id: UUID = UUID(), displayName: String, bookmark: Data, lastIndexed: Date? = nil, trackCount: Int = 0, isReadOnly: Bool = false) {
+    init(id: UUID = UUID(),
+         displayName: String,
+         bookmark: Data,
+         lastIndexed: Date? = nil,
+         trackCount: Int = 0,
+         isReadOnly: Bool = false,
+         lastScanFingerprint: ScanFingerprint? = nil) {
         self.id = id
         self.displayName = displayName
         self.bookmark = bookmark
         self.lastIndexed = lastIndexed
         self.trackCount = trackCount
         self.isReadOnly = isReadOnly
+        self.lastScanFingerprint = lastScanFingerprint
     }
 
     private enum CodingKeys: String, CodingKey {
-        case id, displayName, bookmark, lastIndexed, trackCount, isReadOnly
+        case id, displayName, bookmark, lastIndexed, trackCount, isReadOnly, lastScanFingerprint
     }
 
     init(from decoder: Decoder) throws {
@@ -77,5 +98,6 @@ struct LibraryRoot: Identifiable, Codable, Hashable {
         self.lastIndexed = try c.decodeIfPresent(Date.self, forKey: .lastIndexed)
         self.trackCount = try c.decodeIfPresent(Int.self, forKey: .trackCount) ?? 0
         self.isReadOnly = try c.decodeIfPresent(Bool.self, forKey: .isReadOnly) ?? false
+        self.lastScanFingerprint = try c.decodeIfPresent(ScanFingerprint.self, forKey: .lastScanFingerprint)
     }
 }

--- a/HarmonIQ/Models/Track.swift
+++ b/HarmonIQ/Models/Track.swift
@@ -25,6 +25,11 @@ struct Track: Identifiable, Codable, Hashable {
     var fileSize: Int64
     var fileFormat: String
     var artworkPath: String?
+    /// File's last-modified date at the time of the most recent scan.
+    /// `nil` means the field hasn't been backfilled yet (i.e. the row was
+    /// indexed by a build before issue #55). The next reindex treats nil
+    /// as "unknown — re-extract once" so the field gets populated.
+    var fileModified: Date?
 
     var displayTitle: String { title.isEmpty ? filename : title }
     var displayArtist: String { (artist?.nilIfBlank) ?? (albumArtist?.nilIfBlank) ?? "Unknown Artist" }

--- a/HarmonIQ/Persistence/DriveLibraryStore.swift
+++ b/HarmonIQ/Persistence/DriveLibraryStore.swift
@@ -40,6 +40,10 @@ enum DriveLibraryStore {
         var fileSize: Int64
         var fileFormat: String
         var artworkPath: String?
+        /// File mtime at last scan. Optional so library.json files written
+        /// by builds before issue #55 still decode; treated as "unknown,
+        /// re-extract once" by the indexer to backfill on next scan.
+        var fileModified: Date?
     }
 
     struct DrivePlaylistsFile: Codable {
@@ -148,7 +152,8 @@ enum DriveLibraryStore {
             duration: dt.duration,
             fileSize: dt.fileSize,
             fileFormat: dt.fileFormat,
-            artworkPath: dt.artworkPath
+            artworkPath: dt.artworkPath,
+            fileModified: dt.fileModified
         )
     }
 
@@ -168,7 +173,8 @@ enum DriveLibraryStore {
             duration: t.duration,
             fileSize: t.fileSize,
             fileFormat: t.fileFormat,
-            artworkPath: t.artworkPath
+            artworkPath: t.artworkPath,
+            fileModified: t.fileModified
         )
     }
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -38,6 +38,7 @@ If a section is irrelevant to your PR (e.g. you only touched skin loading), stil
 - [ ] Folders view shows the on-disk structure.
 - [ ] Quit + relaunch app: drive is still listed, tracks appear without re-indexing.
 - [ ] Settings → Reindex (the arrow.clockwise icon next to a drive): completes without errors.
+- [ ] **Incremental reindex** (issue #55): Reindex on an unchanged drive completes near-instantly with "Up to date — N tracks". Add one new file and Reindex → status reads `Indexed N tracks (1 new)`. Delete a file and Reindex → `Indexed N tracks (1 removed)`. Existing `library.json` files (no `fileModified`) load unchanged; the next Reindex backfills.
 
 ---
 


### PR DESCRIPTION
## Summary
Reindex used to walk the entire tree and re-extract metadata + artwork hashes for every file unconditionally — minutes for thousand-track drives even when nothing changed. Now there's a two-tier check:

### 1. Cheap fingerprint short-circuit
Stored on `LibraryRoot.lastScanFingerprint` ({rootMtime, childCount}). If both match the current values, the indexer reports "Up to date — N tracks" and exits without walking.

**Caveat:** in-place file edits (tag changes without rename) don't bump parent-folder mtime, so a user who edits a tag and immediately reindexes might see "Up to date." Adding/removing any file at the drive root invalidates the fingerprint and triggers the full incremental walk. Documented inline.

### 2. Incremental walk
When the cheap check fails, walk the tree but for each file compare its mtime against the stored `Track.fileModified`:
- **unchanged** → reuse the existing Track row, skip metadata + artwork (the expensive parts)
- **modified** → re-extract metadata + artwork
- **new** → full processing
- **missing** (was indexed, now gone) → dropped from the index

Final status: `Indexed N tracks (X new, Y updated, Z removed)` or `Up to date — N tracks` when only unchanged.

## Schema (backward-compatible)
| Field | Where | What |
|---|---|---|
| `Track.fileModified: Date?` | `Track` / `DriveTrack` | mtime at last scan. nil → backfill on next scan. |
| `LibraryRoot.lastScanFingerprint: ScanFingerprint?` | `LibraryRoot` (in `roots.json`) | `{rootMtime, childCount}` for the cheap check. Optional decode. |

Both fields use `decodeIfPresent` / are optional, so existing `library.json` and `roots.json` files migrate transparently.

Closes #55.

## Test plan
- [x] Build green on iPhone 17 sim. App cold-launches.
- [ ] Reindex an unchanged drive completes near-instantly with "Up to date — N tracks".
- [ ] Add one file to the drive, Reindex → status reads `Indexed N tracks (1 new)`; only that file's metadata is extracted (verifiable by progress jumping to ~100% near-instantly with one extraction logged).
- [ ] Delete a file and Reindex → `Indexed N tracks (1 removed)`.
- [ ] Edit tags on a file → Reindex from scratch (toggle the cheap check by adding/removing any other file) → that track's row is updated.
- [ ] Existing `library.json` from a build before this PR loads cleanly; the next Reindex backfills `fileModified` for every track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
