### PR TITLE
Smart Play save in skinned player + auto-incremental on drive load

### DIFF
--- a/HarmonIQ/Persistence/LibraryStore.swift
+++ b/HarmonIQ/Persistence/LibraryStore.swift
@@ -123,22 +123,50 @@ final class LibraryStore: ObservableObject {
         }
 
         let cacheDir = artworkDirectory
-        let result = withDriveAccess(root) { driveURL -> (DriveLibraryStore.DriveLibraryFile?, DriveLibraryStore.DrivePlaylistsFile?) in
+        struct DriveLoad {
+            var library: DriveLibraryStore.DriveLibraryFile?
+            var playlists: DriveLibraryStore.DrivePlaylistsFile?
+            var currentFingerprint: ScanFingerprint?
+        }
+        let result = withDriveAccess(root) { driveURL -> DriveLoad in
             let lib = DriveLibraryStore.loadLibrary(driveRoot: driveURL)
             let pls = DriveLibraryStore.loadPlaylists(driveRoot: driveURL)
             DriveLibraryStore.mirrorArtworkToLocalCache(driveRoot: driveURL, localCache: cacheDir)
-            return (lib, pls)
+            return DriveLoad(library: lib, playlists: pls, currentFingerprint: Self.computeFingerprint(rootURL: driveURL))
         }
-        guard let (lib, pls) = result else { return }
+        guard let result = result else { return }
 
-        if let lib = lib {
+        if let lib = result.library {
             let mapped = lib.tracks.map { DriveLibraryStore.toTrack($0, rootBookmarkID: root.id) }
             mergeTracks(forRoot: root.id, with: mapped)
         }
-        if let pls = pls {
+        if let pls = result.playlists {
             let mapped = pls.playlists.map { DriveLibraryStore.toPlaylist($0, rootBookmarkID: root.id) }
             mergePlaylists(forRoot: root.id, with: mapped)
         }
+
+        // Auto-incremental: if the drive's top-level mtime + child count
+        // differ from the last scan, kick off the indexer so newly-added
+        // files appear without the user having to tap Reindex (issue
+        // #58 / #55 follow-up). The indexer's own cheap-check will
+        // bail near-instantly when nothing changed.
+        if let current = result.currentFingerprint,
+           current != root.lastScanFingerprint,
+           !MusicIndexer.shared.isIndexing {
+            MusicIndexer.shared.index(root: root)
+        }
+    }
+
+    /// Cheap fingerprint helper. Mirrors `MusicIndexer.computeFingerprint` so
+    /// the load path can decide whether to auto-trigger a scan without
+    /// duplicating the file-walking step.
+    private static func computeFingerprint(rootURL: URL) -> ScanFingerprint? {
+        let fm = FileManager.default
+        let rootValues = try? rootURL.resourceValues(forKeys: [.contentModificationDateKey])
+        guard let mtime = rootValues?.contentModificationDate else { return nil }
+        let children = (try? fm.contentsOfDirectory(at: rootURL, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])) ?? []
+        let count = children.filter { $0.lastPathComponent != DriveLibraryStore.folderName }.count
+        return ScanFingerprint(rootMtime: mtime, childCount: count)
     }
 
     private func writePlaylistsToDrive(rootID: UUID) {

--- a/HarmonIQ/Views/Skin/SkinnedMainView.swift
+++ b/HarmonIQ/Views/Skin/SkinnedMainView.swift
@@ -14,6 +14,11 @@ struct SkinnedMainView: View {
     @State private var scrubbingPosition: Double? = nil
     @State private var showSkinPicker = false
     @State private var showSleepMenu = false
+    // Save AI-curated queue as playlist (issue #58 follow-up).
+    @State private var showSavePrompt = false
+    @State private var savePlaylistName = ""
+    @State private var saveToast: String?
+    @State private var saveToastUntil = Date.distantPast
 
     var body: some View {
         GeometryReader { geo in
@@ -57,6 +62,18 @@ struct SkinnedMainView: View {
                     )
 
                     Spacer()
+
+                    if player.aiAnnotation != nil {
+                        Button {
+                            savePlaylistName = defaultSaveName(annotation: player.aiAnnotation)
+                            showSavePrompt = true
+                        } label: {
+                            Image(systemName: "square.and.arrow.down")
+                                .font(.title2)
+                                .foregroundStyle(.white.opacity(0.85), .black.opacity(0.6))
+                        }
+                        .accessibilityLabel("Save AI playlist")
+                    }
 
                     SkinnedFavoriteButton()
                         .environmentObject(player)
@@ -126,8 +143,71 @@ struct SkinnedMainView: View {
             SkinPickerSheet()
                 .environmentObject(skinManager)
         }
+        .alert("Save Smart Play Queue", isPresented: $showSavePrompt) {
+            TextField("Name", text: $savePlaylistName)
+            Button("Save") {
+                let trimmed = savePlaylistName.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !trimmed.isEmpty else { return }
+                performSave(name: trimmed)
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Saves the current AI-curated queue as a regular playlist on the drive that owns most of the tracks.")
+        }
+        .overlay(alignment: .top) { saveToastView }
         .onAppear  { player.setVisualizerActive(true)  }
         .onDisappear { player.setVisualizerActive(false) }
+    }
+
+    @ViewBuilder
+    private var saveToastView: some View {
+        TimelineView(.animation(minimumInterval: 1.0 / 10.0)) { timeline in
+            let remaining = saveToastUntil.timeIntervalSince(timeline.date)
+            if remaining > 0, let msg = saveToast {
+                Text(msg)
+                    .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                    .foregroundStyle(WinampTheme.lcdGlow)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 8)
+                    .background(WinampTheme.lcdBackground.opacity(0.92))
+                    .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(WinampTheme.lcdGlow.opacity(0.6)))
+                    .clipShape(RoundedRectangle(cornerRadius: 4))
+                    .padding(.top, 60)
+                    .opacity(min(1.0, remaining / 0.4))
+            }
+        }
+    }
+
+    private func performSave(name: String) {
+        guard let annotation = player.aiAnnotation else { return }
+        let queueIDs = player.queue.map { $0.stableID }
+        let result = library.saveSmartPlaylist(
+            name: name,
+            trackIDs: queueIDs,
+            prompt: annotation.prompt,
+            mode: annotation.mode
+        )
+        if let result = result {
+            saveToast = result.partial
+                ? "Saved \(result.savedCount) of \(result.totalCount) tracks"
+                : "Saved \(result.savedCount) tracks"
+        } else {
+            saveToast = "Couldn't save — no drive holds the queue"
+        }
+        saveToastUntil = Date().addingTimeInterval(2.0)
+    }
+
+    private func defaultSaveName(annotation: AIQueueAnnotation?) -> String {
+        if let prompt = annotation?.prompt?.trimmingCharacters(in: .whitespacesAndNewlines), !prompt.isEmpty {
+            let titled = prompt.prefix(1).uppercased() + prompt.dropFirst()
+            return String(titled.prefix(40))
+        }
+        if let title = annotation?.title, !title.isEmpty {
+            return String(title.prefix(40))
+        }
+        let df = DateFormatter()
+        df.dateFormat = "yyyy-MM-dd"
+        return "Smart Mix — \(df.string(from: Date()))"
     }
 
     // MARK: - Background


### PR DESCRIPTION
Two iPhone-testing follow-ups:

## Bug 1 — Save AI playlist in the skinned player
The 'Save as Playlist' affordance only existed on the SwiftUI `NowPlayingView`. Users on the Winamp-skinned player had no way to save their Vibe Match queue. Adds the same button to the top chrome bar (visible only when `player.aiAnnotation != nil`), wired to the same alert + `saveSmartPlaylist` + LCD toast.

## Bug 2 — Drive load doesn't auto-detect new tracks
After #55, Reindex skips work when the fingerprint is unchanged. But the user's report was about the prior step: plugging a drive in and *not* tapping Reindex. `loadDriveData` was only reading the cached `library.json`, never comparing to filesystem state.

Now `loadDriveData` computes the fingerprint while it has scope open, and if it differs from the stored one, kicks off `MusicIndexer.shared.index(root:)` automatically. Unchanged drives still no-op; changed drives reconcile in the background without the user lifting a finger.

## Test plan
- [x] Build green on iPhone 17 sim. App cold-launches.
- [ ] Skinned player: run Vibe Match → save button visible in top bar → tap → alert prompts for name → save → row appears in Playlists tab under AI-Curated.
- [ ] Plug drive with new tracks (added externally) → relaunch app → All Tracks shows the new files within a second or two without manually tapping Reindex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)