### PR TITLE
Player icons + force-reindex on user tap

### DIFF
--- a/HarmonIQ/Indexer/MusicIndexer.swift
+++ b/HarmonIQ/Indexer/MusicIndexer.swift
@@ -21,7 +21,11 @@ final class MusicIndexer: ObservableObject {
         statusMessage = "Cancelled"
     }
 
-    func index(root: LibraryRoot) {
+    /// Kick off an index run. When `force` is true the cheap fingerprint
+    /// short-circuit is skipped and the full incremental walk always runs —
+    /// this is the contract the UI's explicit Reindex button relies on, so
+    /// tapping it never silently no-ops.
+    func index(root: LibraryRoot, force: Bool = false) {
         guard !isIndexing else { return }
         isIndexing = true
         progress = 0
@@ -31,7 +35,7 @@ final class MusicIndexer: ObservableObject {
 
         let bookmark = root.bookmark
         let rootID = root.id
-        let priorFingerprint = root.lastScanFingerprint
+        let priorFingerprint = force ? nil : root.lastScanFingerprint
         let localCacheDir = LibraryStore.shared.artworkDirectory
         let priorTracks = LibraryStore.shared.tracks.filter { $0.rootBookmarkID == rootID }
 
@@ -70,13 +74,16 @@ final class MusicIndexer: ObservableObject {
         defer { if started { resolvedURL.stopAccessingSecurityScopedResource() } }
 
         // Cheap top-level fingerprint check. If the drive root's mtime AND
-        // child count both match the last scan, declare "Up to date" and
-        // skip the walk. Caveat: in-place file edits (tag changes without
-        // rename) don't bump folder mtime, so a user who edits tags and
-        // immediately reindexes might see "Up to date" — they can hit
-        // Reindex again later, or add/remove any file at the root to
-        // invalidate the fingerprint. (Issue #55, acceptable tradeoff.)
+        // child count both match the last scan AND we already have tracks
+        // loaded for this drive, declare "Up to date" and skip the walk.
+        // Skipping the cheap-check when priorTracks is empty matters when
+        // the drive's library.json was missing or empty — the fingerprint
+        // could match by luck, and we'd incorrectly say "0 tracks, all
+        // good." Caveat: in-place file edits (tag changes without rename)
+        // don't bump folder mtime; user can hit Reindex (which now passes
+        // force=true and skips this whole block).
         if let fingerprint = priorFingerprint,
+           !priorTracks.isEmpty,
            let current = computeFingerprint(rootURL: resolvedURL),
            current == fingerprint {
             await MainActor.run {

--- a/HarmonIQ/Player/SmartPlay.swift
+++ b/HarmonIQ/Player/SmartPlay.swift
@@ -89,7 +89,7 @@ enum SmartPlayMode: String, CaseIterable, Identifiable {
         case .moodArc:        return "waveform.path.ecg"
         case .deepCut:        return "music.note.house"
         case .onePerArtist:   return "person.3"
-        case .genreTunnel:    return "tunnel"
+        case .genreTunnel:    return "arrow.right.to.line"
         case .eraWalk:        return "clock.arrow.circlepath"
         case .vibeMatch:      return "text.bubble"
         case .storyteller:    return "book"

--- a/HarmonIQ/Views/NowPlayingView.swift
+++ b/HarmonIQ/Views/NowPlayingView.swift
@@ -194,7 +194,7 @@ struct NowPlayingView: View {
                         savePlaylistName = defaultSaveName(annotation: player.aiAnnotation)
                         showSavePrompt = true
                     } label: {
-                        Label("Save as Playlist", systemImage: "square.and.arrow.down")
+                        Label("Save as Playlist", systemImage: "bookmark.fill")
                             .font(.caption.bold())
                             .padding(.horizontal, 12)
                             .padding(.vertical, 6)

--- a/HarmonIQ/Views/SettingsView.swift
+++ b/HarmonIQ/Views/SettingsView.swift
@@ -186,7 +186,12 @@ private struct DriveRow: View {
             }
             Spacer()
             Button {
-                indexer.index(root: root)
+                // Explicit user tap → force a full incremental walk
+                // (skip the cheap fingerprint short-circuit). Otherwise
+                // a stale fingerprint could silently say "up to date"
+                // when the drive's library.json doesn't reflect what's
+                // actually on disk.
+                indexer.index(root: root, force: true)
             } label: {
                 Image(systemName: "arrow.clockwise")
             }

--- a/HarmonIQ/Views/Skin/SkinnedMainView.swift
+++ b/HarmonIQ/Views/Skin/SkinnedMainView.swift
@@ -68,9 +68,10 @@ struct SkinnedMainView: View {
                             savePlaylistName = defaultSaveName(annotation: player.aiAnnotation)
                             showSavePrompt = true
                         } label: {
-                            Image(systemName: "square.and.arrow.down")
+                            Image(systemName: "bookmark.fill")
                                 .font(.title2)
-                                .foregroundStyle(.white.opacity(0.85), .black.opacity(0.6))
+                                .foregroundStyle(Color(red: 0.4, green: 1.0, blue: 0.55).opacity(0.95),
+                                                 .black.opacity(0.6))
                         }
                         .accessibilityLabel("Save AI playlist")
                     }

--- a/HarmonIQ/Views/SleepTimerViews.swift
+++ b/HarmonIQ/Views/SleepTimerViews.swift
@@ -13,7 +13,7 @@ struct SleepTimerButton: View {
         Button {
             showDialog = true
         } label: {
-            Image(systemName: "timer")
+            Image(systemName: "moon.zzz.fill")
                 .font(.title2)
                 .foregroundStyle(isActive ? Color.accentColor : .white.opacity(0.85),
                                  .black.opacity(0.6))
@@ -57,7 +57,7 @@ struct SleepTimerCountdown: View {
     @ViewBuilder
     private func label(text: String) -> some View {
         HStack(spacing: 6) {
-            Image(systemName: "timer")
+            Image(systemName: "moon.zzz.fill")
                 .font(.system(size: 11))
                 .foregroundStyle(WinampTheme.lcdGlow)
             Text(text)


### PR DESCRIPTION
Three iPhone-testing fixes:

## Icons
- **Save as Playlist** `square.and.arrow.down` → `bookmark.fill` (clear save semantics)
- **Sleep timer** `timer` → `moon.zzz.fill` (clear sleep semantics)
- **Genre Tunnel** `tunnel` (iOS 18+, rendered empty on earlier OSes) → `arrow.right.to.line` (iOS 14+)

## Reindex no-op fix
The user reported tapping Reindex did nothing and songs didn't appear. Two compounding causes:

1. The cheap fingerprint short-circuit could match a stale fingerprint by luck and exit with 'Up to date — N tracks' even when the in-memory index is empty / out-of-date.
2. The Reindex button passed no flag to override that.

**Fix:** `MusicIndexer.index(root:force:)` gains a force flag. SettingsView's Reindex button passes `force: true` — explicit user intent always walks. Auto-scans on drive load still use the cheap check.

**Defensive companion:** the cheap check inside runIndex now also skips when `priorTracks` is empty. If the in-memory index has 0 tracks for a drive, we walk regardless of fingerprint — discover files we should have known about.

## Test plan
- [x] Build green on iPhone 17 sim.
- [ ] Player screen icons read as save / sleep at a glance.
- [ ] Smart Play screen: Genre Tunnel row shows the directional-arrow icon.
- [ ] Reindex on a drive with files but stale/missing library.json now walks and populates.
- [ ] Reindex on a truly unchanged drive still completes near-instantly with 'Up to date'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)