### PR TITLE
chore: commit XcodeGen-regenerated Info.plists for 1.0/build 4

### DIFF
--- a/HarmonIQ/Info.plist
+++ b/HarmonIQ/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.4</string>
+	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>3</string>
+	<string>4</string>
 	<key>LSSupportsOpeningDocumentsInPlace</key>
 	<true/>
 	<key>NSAppleMusicUsageDescription</key>

--- a/HarmonIQLiveActivity/Info.plist
+++ b/HarmonIQLiveActivity/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.4</string>
+	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>3</string>
+	<string>4</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>


### PR DESCRIPTION
Followup to PR #69. `xcodegen generate` rewrites `HarmonIQ/Info.plist` and `HarmonIQLiveActivity/Info.plist` from `project.yml`'s inline properties when the bump lands; those generated files were sitting uncommitted at v1.0 tag time. This commit catches them up so a fresh clone builds the 1.0 binary directly.

Tag `v1.0` will be force-updated to this commit after merge so the release points at a buildable tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)