### PR TITLE
Sharpen playback diagnostics for issue #38 (mid-track aborts)

### DIFF
--- a/HarmonIQ/Player/AudioPlayerManager.swift
+++ b/HarmonIQ/Player/AudioPlayerManager.swift
@@ -88,6 +88,10 @@ final class AudioPlayerManager: NSObject, ObservableObject {
     /// `scheduleFile` completion handlers compare against this to detect
     /// whether they belong to a stale schedule that was preempted.
     private var playGeneration: UInt64 = 0
+    /// Tag-claimed duration (`Track.duration`, from AVAsset metadata) for the
+    /// currently-playing track. Compared against the actual file frame count
+    /// at completion to flag VBR-header mismatches (issue #38).
+    private var metadataDurationAtPlay: TimeInterval = 0
     /// Thread-safe meter sink fed by the player-node tap.
     private let meterSink = MeterSink()
 
@@ -289,6 +293,13 @@ final class AudioPlayerManager: NSObject, ObservableObject {
         stopDisplayLink()
         NowPlayingManager.shared.updatePlaybackState(isPlaying: false, currentTime: pausedAtSeconds ?? currentTime, rate: 0.0)
         LiveActivityController.shared.tick(currentTime: pausedAtSeconds ?? currentTime, isPlaying: false)
+        // Issue #38: surfacing every pause helps line up "the song stopped"
+        // with the actual cause when reading the log timeline. We don't know
+        // the caller here, but pairing this with the surrounding logs
+        // (interruption / didFinishPlaying / sleep timer) makes it obvious.
+        let id = currentTrack?.stableID ?? "<none>"
+        let at = pausedAtSeconds ?? 0
+        Self.log.info("pause at=\(at, format: .fixed(precision: 2)) stableID=\(id, privacy: .public)")
     }
 
     func resume() {
@@ -471,6 +482,12 @@ final class AudioPlayerManager: NSObject, ObservableObject {
             let sampleRate = file.processingFormat.sampleRate
             let lengthSeconds = sampleRate > 0 ? Double(file.length) / sampleRate : track.duration
             self.duration = lengthSeconds > 0 ? lengthSeconds : track.duration
+            // Snapshot the metadata duration so the schedule-complete log can
+            // flag a mismatch between what the tag claimed and how many frames
+            // the file actually decoded. Issue #38: the most common
+            // "premature end" cause is a bad VBR header where the metadata
+            // duration is much longer than the audible file length.
+            self.metadataDurationAtPlay = track.duration
 
             playGeneration &+= 1
             let gen = playGeneration
@@ -491,7 +508,11 @@ final class AudioPlayerManager: NSObject, ObservableObject {
             startDisplayLink()
             NowPlayingManager.shared.update(track: track, isPlaying: true, currentTime: 0, duration: self.duration)
             LiveActivityController.shared.updateTrack(track, isPlaying: true, currentTime: 0, duration: self.duration)
-            Self.log.info("playStart stableID=\(track.stableID, privacy: .public) duration=\(self.duration, format: .fixed(precision: 2)) format=\(track.fileFormat, privacy: .public)")
+            // Mismatch between metadata duration and decoded frame count is
+            // the smoking gun for "song aborts mid-playback" reports — log
+            // both so the gap is visible at play-start time.
+            let mismatch = abs(self.duration - track.duration) > 1.0 && track.duration > 0
+            Self.log.info("playStart stableID=\(track.stableID, privacy: .public) fileSeconds=\(self.duration, format: .fixed(precision: 2)) tagSeconds=\(track.duration, format: .fixed(precision: 2)) mismatch=\(mismatch) format=\(track.fileFormat, privacy: .public)")
 
             // If the album has no artwork and the user opted into online
             // lookups, fire a best-effort fetch (issue #73). Off by default;
@@ -579,7 +600,16 @@ final class AudioPlayerManager: NSObject, ObservableObject {
         let observed = currentTimeSeconds()
         let early = totalSeconds > 0 && (totalSeconds - observed) > 1.0
         let id = currentTrack?.stableID ?? "<none>"
-        Self.log.info("didFinishPlaying success=true currentTime=\(observed, format: .fixed(precision: 2)) duration=\(totalSeconds, format: .fixed(precision: 2)) endedEarly=\(early) stableID=\(id, privacy: .public)")
+        let tagSeconds = metadataDurationAtPlay
+        // If the file's actual frame count is materially shorter than the
+        // tag-claimed duration, the file is the culprit (truncated or bad
+        // VBR header). If they agree but `early=true`, something stopped the
+        // schedule prematurely — interruption, engine reset, or AVAudioEngine
+        // bug worth investigating.
+        let tagShortfall = tagSeconds > 0 ? max(0, tagSeconds - totalSeconds) : 0
+        let engineRunning = engine.isRunning
+        let scopeHeld = (accessRoot != nil)
+        Self.log.info("didFinishPlaying success=true currentTime=\(observed, format: .fixed(precision: 2)) fileSeconds=\(totalSeconds, format: .fixed(precision: 2)) tagSeconds=\(tagSeconds, format: .fixed(precision: 2)) tagShortfall=\(tagShortfall, format: .fixed(precision: 2)) endedEarly=\(early) engineRunning=\(engineRunning) scopeHeld=\(scopeHeld) stableID=\(id, privacy: .public)")
 
         if sleepStopAtTrackEnd {
             pause()

--- a/HarmonIQ/Views/SettingsView.swift
+++ b/HarmonIQ/Views/SettingsView.swift
@@ -138,10 +138,15 @@ struct SettingsView: View {
                 } label: {
                     Label("Copy build info", systemImage: "doc.on.clipboard")
                 }
+                Button {
+                    UIPasteboard.general.string = "subsystem:net.leochen.harmoniq category:playback"
+                } label: {
+                    Label("Copy playback log filter", systemImage: "doc.on.clipboard.fill")
+                }
             } header: {
                 Text("Feedback")
             } footer: {
-                Text("Tip: tap “Copy build info” before “Report a bug” — paste it into the issue so we can triage faster.")
+                Text("Tip: tap “Copy build info” before “Report a bug” — paste it into the issue so we can triage faster. For playback bugs (e.g. mid-track aborts), use “Copy playback log filter” and paste it into Console.app while connected to your iPhone to capture the diagnostic stream.")
             }
 
             Section {


### PR DESCRIPTION
Re #38. Adds targeted logging that should make the next "song aborted mid-track" report self-diagnosing — without changing playback behavior.

## Why not a fix?

The bug isn't reliably reproducible (the issue itself notes "Reported anecdotally during normal listening sessions"). The acceptance criteria explicitly allow either a fix or "diagnostic logs added under a debug flag (or always-on at low frequency) that, when the symptom recurs, will tell us *why* the player stopped." This PR takes that path.

## What's new in the log

The existing `Logger(subsystem: "net.leochen.harmoniq", category: "playback")` already covered interruptions, route changes, schedule-complete, scope releases, play-start, and play-fail. What was missing was the metadata-vs-file distinction. Three additions:

1. **`playStart`** — now logs `fileSeconds` (decoded frame count / sample rate) AND `tagSeconds` (`Track.duration` from AVAsset metadata) plus a `mismatch` flag. The most common cause of premature stops on MP3s is a bad VBR header where the tag duration is longer than the actual file. Now visible the moment the track begins.

2. **`didFinishPlaying`** — extended with `tagSeconds`, `tagShortfall`, `engineRunning`, and `scopeHeld`. The combination tells you which bucket the abort fell into:
   - `endedEarly=false`, `tagShortfall>0` → file is truncated, app is fine.
   - `endedEarly=true`, `tagShortfall=0` → schedule stopped early on a file that decoded clean — interruption, engine reset, or a real `AVAudioEngine` bug worth tracking separately.
   - `engineRunning=false` at completion → the engine got torn down (likely a configuration change we didn't restart from).
   - `scopeHeld=false` → security-scoped resource was released mid-playback.

3. **`pause`** — logs at every pause so the timeline of events is readable when correlating with interruption / route-change / sleep-timer logs in Console.app.

## Settings hint

Added a "Copy playback log filter" button under Settings → Feedback that copies `subsystem:net.leochen.harmoniq category:playback` to the clipboard. Users who hit the bug can paste it into Console.app while their iPhone is connected and capture the diagnostic stream without us walking them through it.

## Behavior changes

None. Every change is a `Self.log.info(...)` call. `os_log` writes are cheap and the strings are small.

## Smoke test

- [x] Section A — clean build + launch.
- [x] Build succeeded for iPhone 17 simulator.
- [x] App launches; Settings → Feedback shows the new button.
- [ ] End-to-end: capture a real abort and verify the log line tells the story. Will need a manual session against the user's library — leaving this as a draft until that's confirmed, then can be marked ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)