### PR TITLE
Route tab/nav title color through WinampTheme.lcdGlow

### DIFF
--- a/HarmonIQ/HarmonIQApp.swift
+++ b/HarmonIQ/HarmonIQApp.swift
@@ -48,7 +48,9 @@ struct HarmonIQApp: App {
     }
 
     private static func configureWinampAppearance() {
-        let titleColor = UIColor(red: 0.40, green: 1.00, blue: 0.55, alpha: 1)
+        // Route through the theme so any future tweak to lcdGlow propagates
+        // to the tab/nav title color too. Followup flagged on PR #76.
+        let titleColor = UIColor(WinampTheme.lcdGlow)
 
         let tab = UITabBarAppearance()
         tab.configureWithOpaqueBackground()


### PR DESCRIPTION
## Summary

`HarmonIQApp.configureWinampAppearance` hardcoded `UIColor(red: 0.40, green: 1.00, blue: 0.55)` for the tab + nav title color. That drifted slightly from `WinampTheme.lcdGlow` (which is `(0.40, 1.00, 0.50)`) and wouldn't track any future theme tweak. Use `UIColor(WinampTheme.lcdGlow)` so the color lives in one place.

Followup flagged by the designer on PR #76.

## Test plan

- [x] Section A: app launches in iPhone 17 simulator, no crashes in logs.
- [ ] Section B (manual, on-device): glance at the tab bar / nav title — should look the same to the eye (the change is a 0.05 nudge in the blue channel, which is barely perceptible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)