### PR TITLE
Make EQ preset picker easier to tap and quicker to commit (closes #83)

### DIFF
--- a/HarmonIQ/Player/EqualizerManager.swift
+++ b/HarmonIQ/Player/EqualizerManager.swift
@@ -53,16 +53,22 @@ final class EqualizerManager: ObservableObject {
 
     /// dB gain per band, length 10. -12...+12.
     @Published var bands: [Float] {
-        didSet { applyBands(); persist() }
+        didSet { applyBands(); if !suppressPersist { persist() } }
     }
     /// dB preamp (-12...+12) — mapped to `eqUnit.globalGain`.
     @Published var preamp: Float {
-        didSet { applyPreamp(); persist() }
+        didSet { applyPreamp(); if !suppressPersist { persist() } }
     }
     /// Master bypass. When false, all bands are passed through unchanged.
     @Published var isEnabled: Bool {
-        didSet { applyBypass(); persist() }
+        didSet { applyBypass(); if !suppressPersist { persist() } }
     }
+
+    /// When true, didSet observers skip the per-write `persist()` so a
+    /// multi-property update like `applyPreset` only triggers one
+    /// UserDefaults write. Issue #83 — avoids back-to-back synchronous
+    /// UserDefaults serialization that the user could feel on tap.
+    private var suppressPersist = false
     /// Active preset name (built-in or "Custom" when band gains have been
     /// hand-tuned). Used by the UI to highlight the active row.
     @Published private(set) var activePreset: String
@@ -100,10 +106,17 @@ final class EqualizerManager: ObservableObject {
     }
 
     func applyPreset(_ preset: EqualizerPreset) {
+        // Coalesce all the writes into a single persist() at the end so a
+        // preset commit feels instant — issue #83. Without this, setting
+        // bands then preamp triggers two separate UserDefaults serializations
+        // back-to-back on the main thread.
+        suppressPersist = true
         bands = preset.bands
         preamp = preset.preamp
+        suppressPersist = false
         activePreset = preset.name
         UserDefaults.standard.set(preset.name, forKey: presetKey)
+        persist()
     }
 
     func resetToFlat() { applyPreset(.flat) }

--- a/HarmonIQ/Views/Skin/SkinnedEqualizerView.swift
+++ b/HarmonIQ/Views/Skin/SkinnedEqualizerView.swift
@@ -48,20 +48,32 @@ struct SkinnedEqualizerView: View {
                         Label("Reset to Flat", systemImage: "arrow.counterclockwise")
                     }
                 } label: {
-                    HStack(spacing: 3) {
+                    // Issue #83: bumped font 10→11, padding h:6/v:2 → h:10/v:6
+                    // (~74×26 visible chip + outer .padding extends the hit
+                    // surface another 4pt). The EQ header is space-
+                    // constrained so we can't quite hit Apple's 44pt HIG
+                    // minimum, but this is well above the previous ~50×14 and
+                    // first-tap dispatch on the SwiftUI Menu becomes reliable
+                    // because the label's hit shape is now meaningfully
+                    // larger than the surrounding text.
+                    HStack(spacing: 4) {
                         Text(eq.activePreset.uppercased())
-                            .font(.system(size: 10, weight: .bold, design: .monospaced))
+                            .font(.system(size: 11, weight: .bold, design: .monospaced))
                         Image(systemName: "chevron.down")
-                            .font(.system(size: 8, weight: .bold))
+                            .font(.system(size: 9, weight: .bold))
                     }
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
                     .foregroundStyle(activeColor)
-                    .background(activeColor.opacity(0.12))
-                    .overlay(RoundedRectangle(cornerRadius: 2).strokeBorder(activeColor.opacity(0.5)))
-                    .clipShape(RoundedRectangle(cornerRadius: 2))
+                    .background(activeColor.opacity(0.18))
+                    .overlay(RoundedRectangle(cornerRadius: 3).strokeBorder(activeColor.opacity(0.55)))
+                    .clipShape(RoundedRectangle(cornerRadius: 3))
+                    .padding(4)
+                    .contentShape(Rectangle())
                 }
+                .menuOrder(.fixed)
                 .accessibilityLabel("Equalizer presets")
+                .accessibilityHint("Active preset: \(eq.activePreset)")
             }
             .padding(.horizontal, 8)
             .padding(.vertical, 4)


### PR DESCRIPTION
## Summary

User reported the equalizer preset chooser is "still not very responsive, hard to choose and took some time to select one preset" — distinct from the visualizer picker fixed in PR #80, this is the real audio EQ in the skinned chrome.

Three changes:

- **Bigger hit target.** Bumped chip font 10→11pt, padding from h:6/v:2 to h:10/v:6, plus a 4pt outer `.padding` + `.contentShape(Rectangle())` to extend the tap surface another 4pt outside the chip outline. Previous ~50×14 hit area was below Apple's 44pt HIG minimum and was eating first-tap dispatch on the SwiftUI Menu.
- **Coalesced persist on apply.** `applyPreset(_:)` was setting `bands` then `preamp`, each firing didSet → persist() → synchronous UserDefaults serialization of a 10-float array. Two of those back-to-back on the main thread was enough to feel laggy on tap. Added a `suppressPersist` flag so a multi-property update triggers exactly one persist at the end.
- **Visual feedback.** Background opacity 0.12→0.18, stroke 0.55, plus `.menuOrder(.fixed)` so the preset list appears in declared order (Flat, Rock, Pop, ...) instead of SwiftUI's default reversed order.

Verified there are no parent gestures in `SkinnedMainView` competing with the Menu — the only `.simultaneousGesture` calls are on chrome buttons up top.

## Test plan

- [x] Section A: app builds and launches in iPhone 17 simulator (iOS 26.4), no warnings, no crashes in logs.
- [ ] Section B (manual, on-device): switch into a skinned player, tap the preset chip in the EQ header. Menu should open on first tap. Pick a non-Flat preset (e.g. Rock) — sliders should snap to the new gains within a frame.
- [ ] Section B (manual, on-device): kill and relaunch — confirm the picked preset is restored.
- [ ] Section B (manual, on-device): drag a band slider away from the preset → chip label should change to "CUSTOM". Verify EQ on/off toggle right next to the chip is unaffected (no regression from the layout changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)