### PR TITLE
Fix duplicated albums + per-drive Rebuild action (#88)

### DIFF
--- a/HarmonIQ/Persistence/LibraryStore.swift
+++ b/HarmonIQ/Persistence/LibraryStore.swift
@@ -388,6 +388,38 @@ final class LibraryStore: ObservableObject {
         saveRoots()
     }
 
+    /// Wipes the on-drive (or sandbox-shadow) `library.json` for `root`,
+    /// drops in-memory tracks for that drive, clears the drive's stored
+    /// fingerprint so the next scan walks the full filesystem, and
+    /// returns. Playlists are intentionally preserved — they reference
+    /// tracks by `stableID` (drive-relative `sha1(relativePath)`), which
+    /// stays valid as long as the audio files are still at the same paths.
+    /// The caller is expected to kick off `MusicIndexer.index(root:force:)`
+    /// after this returns. Settings does this with a confirmation dialog
+    /// (issue #88).
+    func rebuildLibrary(for root: LibraryRoot) {
+        // 1. Drop in-memory tracks for this drive.
+        tracks.removeAll { $0.rootBookmarkID == root.id }
+        // 2. Delete the persisted index file so a fresh scan starts from
+        //    nothing — no stale rows hanging around if the indexer is
+        //    interrupted mid-rebuild.
+        if root.isReadOnly {
+            try? FileManager.default.removeItem(at: SandboxRootStore.libraryFile(rootID: root.id))
+        } else {
+            withDriveAccess(root) { driveURL in
+                let url = DriveLibraryStore.libraryFile(in: driveURL)
+                try? FileManager.default.removeItem(at: url)
+            }
+        }
+        // 3. Clear the cheap-check fingerprint + track count so the next
+        //    scan can't short-circuit on "Up to date".
+        if let idx = roots.firstIndex(where: { $0.id == root.id }) {
+            roots[idx].lastScanFingerprint = nil
+            roots[idx].trackCount = 0
+            saveRoots()
+        }
+    }
+
     func removeRoot(_ root: LibraryRoot) {
         roots.removeAll { $0.id == root.id }
         // Drop in-memory tracks/playlists belonging to this drive. The on-drive files
@@ -426,7 +458,21 @@ final class LibraryStore: ObservableObject {
 
     private func mergeTracks(forRoot rootID: UUID, with newTracks: [Track]) {
         var preserved = tracks.filter { $0.rootBookmarkID != rootID }
-        preserved.append(contentsOf: newTracks)
+        // Uniqueness invariant (issue #88): a single drive must never carry
+        // two tracks with the same stableID. The indexer already enforces
+        // this by construction, but defensively dedupe on every merge so a
+        // bad library.json on disk (or a future bug) can't poison memory.
+        // Keep first occurrence — this matches how the indexer iterates the
+        // filesystem (alphabetic) so the choice is deterministic.
+        var seen: Set<String> = []
+        var deduped: [Track] = []
+        deduped.reserveCapacity(newTracks.count)
+        for t in newTracks {
+            if seen.insert(t.stableID).inserted {
+                deduped.append(t)
+            }
+        }
+        preserved.append(contentsOf: deduped)
         preserved.sort { lhs, rhs in
             lhs.relativePath.joined(separator: "/").localizedStandardCompare(rhs.relativePath.joined(separator: "/")) == .orderedAscending
         }
@@ -623,15 +669,84 @@ final class LibraryStore: ObservableObject {
         tracks.filter { $0.displayArtist == artist }
     }
 
+    /// Identifier for a single album row in the Albums view. Two flavours:
+    ///
+    /// - **Single-artist** (`isCompilation == false`): the conventional
+    ///   `(album, artist)` pair. Two tracks belong to the same album iff
+    ///   they share both fields.
+    /// - **Compilation** (`isCompilation == true`): album-only grouping.
+    ///   `artist` is set to `"Various Artists"` for display. Triggered when
+    ///   the same album string appears with ≥3 distinct artists on the same
+    ///   drive (issue #88) — collapses fragmented "1995 Grammy Nominees"
+    ///   rows into a single entry.
     struct AlbumKey: Hashable, Identifiable {
         let album: String
         let artist: String
-        var id: String { "\(artist)|\(album)" }
+        let isCompilation: Bool
+        var id: String { isCompilation ? "compilation|\(album)" : "\(artist)|\(album)" }
+
+        init(album: String, artist: String, isCompilation: Bool = false) {
+            self.album = album
+            self.artist = artist
+            self.isCompilation = isCompilation
+        }
+    }
+
+    static let variousArtistsLabel = "Various Artists"
+
+    /// Threshold for compilation detection: when the same album string on
+    /// one drive appears with at least this many distinct displayArtist
+    /// values, treat it as a Various-Artists compilation and collapse to a
+    /// single album row. Three matches the issue #88 ask: pragmatic, avoids
+    /// false-positive collapses on duo albums where the artist field is
+    /// noisy ("Artist A; Artist B" / "Artist A feat. Artist B").
+    private static let compilationArtistThreshold = 3
+
+    /// Albums on a given drive that look like compilations (same album,
+    /// many artists). Computed once per `tracks` snapshot and used to
+    /// decide whether `(album, artist)` keys collapse into a single
+    /// "Various Artists" row.
+    private func compilationAlbumsByRoot() -> [UUID: Set<String>] {
+        var perRoot: [UUID: [String: Set<String>]] = [:]
+        for t in tracks {
+            // Use the raw album field — fall back to displayAlbum when nil
+            // so "Unknown Album" rows aren't treated as one giant comp.
+            let album = t.displayAlbum
+            // Skip "Unknown Album" entirely: a drive full of orphan tracks
+            // would otherwise collapse into a single fake compilation.
+            if album == "Unknown Album" { continue }
+            perRoot[t.rootBookmarkID, default: [:]][album, default: []].insert(t.displayArtist)
+        }
+        var out: [UUID: Set<String>] = [:]
+        for (rootID, albums) in perRoot {
+            var comps: Set<String> = []
+            for (album, artists) in albums where artists.count >= Self.compilationArtistThreshold {
+                comps.insert(album)
+            }
+            if !comps.isEmpty { out[rootID] = comps }
+        }
+        return out
+    }
+
+    /// True when `track`'s album/drive pair is a compilation in the
+    /// current library. Used by callers that need to decide whether the
+    /// track should be displayed under a single Various-Artists row.
+    func isCompilationTrack(_ track: Track) -> Bool {
+        let comps = compilationAlbumsByRoot()
+        return comps[track.rootBookmarkID]?.contains(track.displayAlbum) ?? false
     }
 
     var allAlbums: [AlbumKey] {
+        let comps = compilationAlbumsByRoot()
         var set: Set<AlbumKey> = []
-        for t in tracks { set.insert(AlbumKey(album: t.displayAlbum, artist: t.displayArtist)) }
+        for t in tracks {
+            let isComp = comps[t.rootBookmarkID]?.contains(t.displayAlbum) ?? false
+            if isComp {
+                set.insert(AlbumKey(album: t.displayAlbum, artist: Self.variousArtistsLabel, isCompilation: true))
+            } else {
+                set.insert(AlbumKey(album: t.displayAlbum, artist: t.displayArtist))
+            }
+        }
         return set.sorted { lhs, rhs in
             if lhs.album != rhs.album {
                 return lhs.album.localizedStandardCompare(rhs.album) == .orderedAscending
@@ -641,12 +756,23 @@ final class LibraryStore: ObservableObject {
     }
 
     func tracks(forAlbum key: AlbumKey) -> [Track] {
-        tracks.filter { $0.displayAlbum == key.album && $0.displayArtist == key.artist }
-            .sorted { lhs, rhs in
-                if let l = lhs.discNumber, let r = rhs.discNumber, l != r { return l < r }
-                if let l = lhs.trackNumber, let r = rhs.trackNumber, l != r { return l < r }
-                return lhs.displayTitle.localizedStandardCompare(rhs.displayTitle) == .orderedAscending
+        let matches: [Track]
+        if key.isCompilation {
+            // Compilation: every track on any drive whose album string
+            // matches AND whose drive flagged this album as a comp.
+            let comps = compilationAlbumsByRoot()
+            matches = tracks.filter { t in
+                guard t.displayAlbum == key.album else { return false }
+                return comps[t.rootBookmarkID]?.contains(t.displayAlbum) ?? false
             }
+        } else {
+            matches = tracks.filter { $0.displayAlbum == key.album && $0.displayArtist == key.artist }
+        }
+        return matches.sorted { lhs, rhs in
+            if let l = lhs.discNumber, let r = rhs.discNumber, l != r { return l < r }
+            if let l = lhs.trackNumber, let r = rhs.trackNumber, l != r { return l < r }
+            return lhs.displayTitle.localizedStandardCompare(rhs.displayTitle) == .orderedAscending
+        }
     }
 
     func search(_ query: String) -> [Track] {

--- a/HarmonIQ/Views/SettingsView.swift
+++ b/HarmonIQ/Views/SettingsView.swift
@@ -19,6 +19,7 @@ struct SettingsView: View {
     @StateObject private var artworkFetcher = ArtworkFetcher.shared
     @State private var showPicker = false
     @State private var bulkConfirmRoot: LibraryRoot?
+    @State private var rebuildConfirmRoot: LibraryRoot?
 
     var body: some View {
         List {
@@ -105,6 +106,22 @@ struct SettingsView: View {
                 Text("Artwork")
             } footer: {
                 Text("Off by default. When on, HarmonIQ sends the album + artist of any track without local art to MusicBrainz to find a cover. Failures are silent — no other data leaves the device.\n\n“Rescan artwork on disk” adopts any covers you dropped into <Drive>/HarmonIQ/Artwork/ matching the sha1(albumArtist|album).jpg naming convention. Files that don't match a known album are ignored.")
+            }
+
+            Section {
+                ForEach(library.roots) { root in
+                    Button(role: .destructive) {
+                        rebuildConfirmRoot = root
+                    } label: {
+                        Label("Rebuild library — \(root.displayName)",
+                              systemImage: "arrow.counterclockwise.circle")
+                    }
+                    .disabled(indexer.isIndexing)
+                }
+            } header: {
+                Text("Maintenance")
+            } footer: {
+                Text("Wipes the drive's library.json and runs a fresh full scan. Use this if the album list is duplicated or has stale entries (issue #88). Playlists survive as long as the audio files are still at the same paths on the drive. Favorites, smart playlists, and roots.json are preserved.")
             }
 
             Section {
@@ -203,6 +220,21 @@ struct SettingsView: View {
             Button("Cancel", role: .cancel) { bulkConfirmRoot = nil }
         } message: {
             Text("This sends one MusicBrainz query per album missing artwork on \(bulkConfirmRoot?.displayName ?? "this drive"), at most 1 request per second. Failures are silent.")
+        }
+        .confirmationDialog("Rebuild library from scratch?",
+                            isPresented: Binding(get: { rebuildConfirmRoot != nil },
+                                                 set: { if !$0 { rebuildConfirmRoot = nil } }),
+                            titleVisibility: .visible) {
+            Button("Rebuild", role: .destructive) {
+                if let r = rebuildConfirmRoot {
+                    library.rebuildLibrary(for: r)
+                    indexer.index(root: r, force: true)
+                }
+                rebuildConfirmRoot = nil
+            }
+            Button("Cancel", role: .cancel) { rebuildConfirmRoot = nil }
+        } message: {
+            Text("Deletes \(rebuildConfirmRoot?.displayName ?? "this drive")'s library.json and runs a fresh scan. Playlists survive as long as audio files stay at the same paths. The bookmark and favorites are preserved.")
         }
     }
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,47 @@
+# tools/
+
+Offline maintenance scripts for HarmonIQ. These run from a Mac terminal with
+the music drive mounted at any path — they operate on the on-drive
+`HarmonIQ/library.json` directly, no app required.
+
+## library-doctor.swift (issue #88)
+
+Diagnose and repair a drive whose Albums view is bloated with duplicates.
+
+```bash
+# Diagnose — read-only, prints duplicate stableID counts and compilation candidates.
+swift tools/library-doctor.swift --report  /Volumes/Music
+
+# Collapse rows that share a stableID (sha1(relativePath)). Keeps the first.
+# Writes back to library.json atomically.
+swift tools/library-doctor.swift --dedupe  /Volumes/Music
+
+# Nuke library.json so the next app launch reindexes from scratch.
+# Playlists at HarmonIQ/playlists.json are left alone — they reference tracks
+# by stableID, which a clean reindex regenerates.
+swift tools/library-doctor.swift --rebuild /Volumes/Music
+```
+
+The path argument is the **drive root you picked in HarmonIQ** (the parent of
+`HarmonIQ/`), not the `HarmonIQ/` folder itself.
+
+### When to use which mode
+
+| Symptom | Mode |
+| --- | --- |
+| "I want to see what's going on before touching anything." | `--report` |
+| Same track appears twice in the same album. | `--dedupe` |
+| Albums look fragmented (one "1995 Grammy Nominees" per artist) and the in-app Rebuild action isn't enough. | `--rebuild` |
+
+The in-app *Settings → Maintenance → Rebuild library* action is the same
+operation as `--rebuild`, just triggered from the phone. Use the script when
+the device isn't handy or when you want to script bulk maintenance across
+several drives.
+
+### Limitations
+
+- Read-only roots (where the index lives in the app sandbox, not on the
+  drive) aren't reachable from this script — Settings is the only path.
+- Compilation grouping in the in-app Albums view is purely a UI fold-up
+  (issue #88); `--report` flags compilation candidates but doesn't
+  rewrite anything. Use it as a sanity check.

--- a/tools/library-doctor.swift
+++ b/tools/library-doctor.swift
@@ -1,0 +1,209 @@
+#!/usr/bin/env swift
+//
+// library-doctor.swift — offline maintenance for HarmonIQ's on-drive library.json.
+//
+// Usage (see tools/README.md for the long version):
+//
+//   swift tools/library-doctor.swift --report  /Volumes/Music
+//   swift tools/library-doctor.swift --dedupe  /Volumes/Music
+//   swift tools/library-doctor.swift --rebuild /Volumes/Music
+//
+// The drive path is the folder you picked in HarmonIQ (the parent of
+// `HarmonIQ/library.json`), not the `HarmonIQ/` folder itself.
+//
+// This script is self-contained: it duplicates the on-disk JSON shape so
+// HarmonIQ.app doesn't need to be linked. If `DriveLibraryStore.DriveTrack`
+// gains required fields, mirror them here too.
+//
+// Issue #88.
+
+import Foundation
+
+// MARK: - On-disk shape (mirrors DriveLibraryStore.DriveTrack / DriveLibraryFile)
+
+struct DriveTrack: Codable {
+    var stableID: String
+    var relativePath: [String]
+    var filename: String
+    var title: String
+    var artist: String?
+    var album: String?
+    var albumArtist: String?
+    var genre: String?
+    var year: Int?
+    var trackNumber: Int?
+    var discNumber: Int?
+    var duration: Double
+    var fileSize: Int64
+    var fileFormat: String
+    var artworkPath: String?
+    var fileModified: Date?
+    /// Issue #86 field — optional in v1, populated by the indexer.
+    var language: String?
+}
+
+struct DriveLibraryFile: Codable {
+    var version: Int
+    var tracks: [DriveTrack]
+}
+
+// MARK: - CLI
+
+enum Mode: String {
+    case report = "--report"
+    case dedupe = "--dedupe"
+    case rebuild = "--rebuild"
+}
+
+func usage() -> Never {
+    let msg = """
+    library-doctor — HarmonIQ library.json maintenance
+
+    USAGE:
+      swift tools/library-doctor.swift --report  <drive-root>
+      swift tools/library-doctor.swift --dedupe  <drive-root>
+      swift tools/library-doctor.swift --rebuild <drive-root>
+
+    MODES:
+      --report   Print compilation albums and duplicate stableID counts. Read-only.
+      --dedupe   Collapse rows that share a stableID (keeps the first). Writes back.
+      --rebuild  Delete library.json so the next app launch reindexes from scratch.
+                 Playlists survive — they reference tracks by stableID
+                 (sha1(relativePath)), which a clean reindex regenerates.
+
+    <drive-root> is the folder you picked in HarmonIQ — the PARENT of HarmonIQ/.
+    """
+    FileHandle.standardError.write(Data(msg.utf8) + Data("\n".utf8))
+    exit(64)
+}
+
+let args = CommandLine.arguments
+guard args.count == 3, let mode = Mode(rawValue: args[1]) else { usage() }
+let driveRoot = URL(fileURLWithPath: args[2], isDirectory: true)
+let libraryURL = driveRoot
+    .appendingPathComponent("HarmonIQ", isDirectory: true)
+    .appendingPathComponent("library.json")
+
+// MARK: - IO helpers
+
+let decoder: JSONDecoder = {
+    let d = JSONDecoder()
+    d.dateDecodingStrategy = .iso8601
+    return d
+}()
+
+let encoder: JSONEncoder = {
+    let e = JSONEncoder()
+    e.outputFormatting = [.prettyPrinted, .sortedKeys]
+    e.dateEncodingStrategy = .iso8601
+    return e
+}()
+
+func readLibrary() -> DriveLibraryFile {
+    do {
+        let data = try Data(contentsOf: libraryURL)
+        return try decoder.decode(DriveLibraryFile.self, from: data)
+    } catch {
+        FileHandle.standardError.write(Data("error: couldn't read \(libraryURL.path): \(error)\n".utf8))
+        exit(2)
+    }
+}
+
+func writeLibraryAtomically(_ file: DriveLibraryFile) {
+    do {
+        let data = try encoder.encode(file)
+        try data.write(to: libraryURL, options: .atomic)
+    } catch {
+        FileHandle.standardError.write(Data("error: couldn't write \(libraryURL.path): \(error)\n".utf8))
+        exit(3)
+    }
+}
+
+// MARK: - Modes
+
+func runReport() {
+    let lib = readLibrary()
+    print("library.json: \(libraryURL.path)")
+    print("version: \(lib.version)  tracks: \(lib.tracks.count)")
+    print("")
+
+    // Duplicate stableID rows.
+    var counts: [String: Int] = [:]
+    for t in lib.tracks { counts[t.stableID, default: 0] += 1 }
+    let dupes = counts.filter { $0.value > 1 }
+    if dupes.isEmpty {
+        print("stableID uniqueness: OK")
+    } else {
+        let total = dupes.values.reduce(0, +) - dupes.count
+        print("stableID uniqueness: FAIL — \(dupes.count) ids account for \(total) extra rows")
+        let sample = dupes.sorted { $0.value > $1.value }.prefix(5)
+        for (sid, n) in sample {
+            print("  \(sid)  ×\(n)")
+        }
+    }
+    print("")
+
+    // Compilation candidates: same album with ≥3 distinct artists.
+    var byAlbum: [String: Set<String>] = [:]
+    for t in lib.tracks {
+        let album = (t.album ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !album.isEmpty else { continue }
+        let artist = (t.artist ?? t.albumArtist ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !artist.isEmpty else { continue }
+        byAlbum[album, default: []].insert(artist)
+    }
+    let comps = byAlbum.filter { $0.value.count >= 3 }
+        .sorted { $0.value.count > $1.value.count }
+    if comps.isEmpty {
+        print("compilations: none detected (≥3 distinct artists per album threshold)")
+    } else {
+        print("compilations: \(comps.count) album(s) look like compilations:")
+        for (album, artists) in comps.prefix(20) {
+            print("  \(album)  (\(artists.count) distinct artists)")
+        }
+        if comps.count > 20 { print("  … and \(comps.count - 20) more") }
+    }
+}
+
+func runDedupe() {
+    let lib = readLibrary()
+    var seen: Set<String> = []
+    var deduped: [DriveTrack] = []
+    deduped.reserveCapacity(lib.tracks.count)
+    for t in lib.tracks {
+        if seen.insert(t.stableID).inserted {
+            deduped.append(t)
+        }
+    }
+    let removed = lib.tracks.count - deduped.count
+    if removed == 0 {
+        print("dedupe: nothing to do — already unique on stableID (\(lib.tracks.count) tracks).")
+        return
+    }
+    var out = lib
+    out.tracks = deduped
+    writeLibraryAtomically(out)
+    print("dedupe: collapsed \(removed) duplicate row(s); \(deduped.count) unique tracks remain.")
+}
+
+func runRebuild() {
+    if FileManager.default.fileExists(atPath: libraryURL.path) {
+        do {
+            try FileManager.default.removeItem(at: libraryURL)
+            print("rebuild: deleted \(libraryURL.path).")
+        } catch {
+            FileHandle.standardError.write(Data("error: couldn't delete \(libraryURL.path): \(error)\n".utf8))
+            exit(4)
+        }
+    } else {
+        print("rebuild: \(libraryURL.path) wasn't there — nothing to delete.")
+    }
+    print("rebuild: launch HarmonIQ on a device with this drive mounted to reindex from scratch.")
+    print("rebuild: playlists at HarmonIQ/playlists.json were left alone.")
+}
+
+switch mode {
+case .report:  runReport()
+case .dedupe:  runDedupe()
+case .rebuild: runRebuild()
+}


### PR DESCRIPTION
## Linked issue

Closes #88

## Summary

- Albums view collapses into a single "Various Artists" entry when the same album string on one drive carries ≥3 distinct artists (compilation heuristic from the issue body). Single-artist albums are unaffected.
- `LibraryStore.mergeTracks` now defensively dedupes per-drive on `stableID` so a stale `library.json` can't surface duplicate rows.
- New Settings → Maintenance → Rebuild action (per drive, with destructive confirmation) wipes `library.json`, clears the fingerprint, and kicks off a forced reindex. Playlists survive a rebuild because they reference tracks by `stableID`.
- New offline `tools/library-doctor.swift` script with `--report`, `--dedupe`, `--rebuild`. Operates on `<DriveRoot>/HarmonIQ/library.json` directly. Documented in `tools/README.md`.

## Test plan (PR-specific)

- [x] Index a drive that contains a "1995 Grammy Nominees"-style compilation — verify the Albums view shows ONE entry attributed "Various Artists" with all tracks visible inside.
- [x] Verify `mergeTracks` dedupe path: load a `library.json` containing two rows with the same `stableID` — only one survives in memory.
- [x] Settings → Maintenance → Rebuild prompts for confirmation, then wipes the drive's library and reindexes from scratch.
- [x] Run `swift tools/library-doctor.swift` with no args — usage prints.

## Regression check

- [x] **A. Build + launch** (iPhone 17 simulator)
- [x] B. Library + drive flow

## Notes / known v1 limitations

- The compilation heuristic is purely a UI fold-up — `library.json` still stores per-track `albumArtist` values. This means cross-drive compilations (same album on two drives) collapse independently, which is fine for the v1 ask.
- The script is read/write only against `library.json`; read-only roots (sandbox-resident index) aren't reachable from the script. Use the in-app Rebuild action for those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)