### PR TITLE
Browse library by language: Chinese / English / Others (#86)

### DIFF
--- a/HarmonIQ.xcodeproj/project.pbxproj
+++ b/HarmonIQ.xcodeproj/project.pbxproj
@@ -33,7 +33,9 @@
 		77D9EEF75A3909296BEF427B /* SkinSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CC7D5B7F672E031A0E10CD5 /* SkinSettingsView.swift */; };
 		791A8D34EE8AB6E905502339 /* BitmapNumbers.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED17D95227132C92484D37D4 /* BitmapNumbers.swift */; };
 		7F8EEECCAE52592D4BBAF6D1 /* BookmarkStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA0C5DAF97A47E057019501 /* BookmarkStore.swift */; };
+		81403F7C2A60B5A1AD91C5CA /* LanguageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46422ECF0A72BFA4BD1BCD69 /* LanguageView.swift */; };
 		81A7F353D3DE8032677CF41A /* HarmonIQLiveActivity.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = FB11BD031B719E529ADE16FC /* HarmonIQLiveActivity.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		871C62AB9C1A5A797C65D845 /* TrackLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96EBCE54D7F402D33BAF93EE /* TrackLanguage.swift */; };
 		89D7DBC59590AF415A3B0191 /* SkinnedVolumeSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 645788E38767A20E50B440A4 /* SkinnedVolumeSlider.swift */; };
 		8CEA6C7112AA776066EDEE1E /* BitmapSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5341339CB5BD57C71DD7EC /* BitmapSlider.swift */; };
 		8E0DD1135723468147BBB31D /* PlaylistsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B4DEE2EB2331B3F5BB20CB2 /* PlaylistsView.swift */; };
@@ -104,6 +106,7 @@
 		3B4DEE2EB2331B3F5BB20CB2 /* PlaylistsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistsView.swift; sourceTree = "<group>"; };
 		3D1E6758360675D09C68F165 /* BuildInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildInfo.swift; sourceTree = "<group>"; };
 		3D6EA2A86E18C3306B3A4BFC /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		46422ECF0A72BFA4BD1BCD69 /* LanguageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageView.swift; sourceTree = "<group>"; };
 		4A34D43E2D09B36F9A92DF67 /* WinampTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WinampTheme.swift; sourceTree = "<group>"; };
 		4D55B677D3210BEAEDFEA0C5 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		55024EA44411432F49AA2A6C /* HarmonIQLiveActivityWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarmonIQLiveActivityWidget.swift; sourceTree = "<group>"; };
@@ -115,6 +118,7 @@
 		7D9E86967B7801F70269E055 /* Skins */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Skins; path = HarmonIQ/Resources/Skins; sourceTree = SOURCE_ROOT; };
 		8CA5D219A5FF2CBA19A0E003 /* LibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryView.swift; sourceTree = "<group>"; };
 		91184AF88772B10074EACE0A /* SkinnedEqualizerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkinnedEqualizerView.swift; sourceTree = "<group>"; };
+		96EBCE54D7F402D33BAF93EE /* TrackLanguage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackLanguage.swift; sourceTree = "<group>"; };
 		978941B5C224F0EFA9E46A90 /* AudioPlayerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPlayerManager.swift; sourceTree = "<group>"; };
 		982616423A6BC3BB174F0A2E /* SkinFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkinFormat.swift; sourceTree = "<group>"; };
 		99DCB9BA8F0F6EA560429A13 /* ArtworkFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtworkFetcher.swift; sourceTree = "<group>"; };
@@ -199,6 +203,7 @@
 			children = (
 				D210ACF5D89E9E21A1496719 /* Playlist.swift */,
 				DCC1E5260F8BCC82F22321CD /* Track.swift */,
+				96EBCE54D7F402D33BAF93EE /* TrackLanguage.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -250,6 +255,7 @@
 				21D6E4A738A357E6A860D0E0 /* ArtistsView.swift */,
 				3D6EA2A86E18C3306B3A4BFC /* ContentView.swift */,
 				E35D430429E1AB1C5D29D971 /* FoldersView.swift */,
+				46422ECF0A72BFA4BD1BCD69 /* LanguageView.swift */,
 				8CA5D219A5FF2CBA19A0E003 /* LibraryView.swift */,
 				38FE23F9FF831246E93D46D0 /* NowPlayingView.swift */,
 				3B4DEE2EB2331B3F5BB20CB2 /* PlaylistsView.swift */,
@@ -492,6 +498,7 @@
 				9546DB969B9FE4BEBDBF9F76 /* FoldersView.swift in Sources */,
 				B84CEA38828817F440C90762 /* HarmonIQActivityAttributes.swift in Sources */,
 				DAC622E13BE984A57D2E9C86 /* HarmonIQApp.swift in Sources */,
+				81403F7C2A60B5A1AD91C5CA /* LanguageView.swift in Sources */,
 				5DB383E665EE8EAE33D78E9C /* LibraryStore.swift in Sources */,
 				A10BD1CC54DC77E7DF551BA6 /* LibraryView.swift in Sources */,
 				116A7F3DD4FF063CD5776F50 /* LiveActivityController.swift in Sources */,
@@ -521,6 +528,7 @@
 				77B3E1181A2A2CBFAD277C5E /* SmartPlayView.swift in Sources */,
 				69A2102040E365274784D9BD /* SpriteButton.swift in Sources */,
 				75DC9743887154D3D3823A75 /* Track.swift in Sources */,
+				871C62AB9C1A5A797C65D845 /* TrackLanguage.swift in Sources */,
 				492B4DC977A439789D0DA1D9 /* VisualizerSettingsView.swift in Sources */,
 				EC778E91CBFC41C1A6A09A2A /* Visualizers.swift in Sources */,
 				ADFA445F84DD3EDB1A55C5DB /* WinampSkin.swift in Sources */,

--- a/HarmonIQ/Indexer/MusicIndexer.swift
+++ b/HarmonIQ/Indexer/MusicIndexer.swift
@@ -167,7 +167,13 @@ final class MusicIndexer: ObservableObject {
                let storedMtime = existing.fileModified,
                let mtime = mtime,
                abs(storedMtime.timeIntervalSince(mtime)) < 1 {
-                tracks.append(existing)
+                // Backfill language for rows indexed before issue #86 — pure
+                // string scan, cheap. Skips reuse path otherwise.
+                var reused = existing
+                if reused.language == nil {
+                    reused.language = TrackLanguage.classify(title: reused.title, artist: reused.artist)
+                }
+                tracks.append(reused)
                 unchanged += 1
                 if let path = existing.artworkPath {
                     seenArtworkKeys.insert((path as NSString).deletingPathExtension)
@@ -218,6 +224,7 @@ final class MusicIndexer: ObservableObject {
                 }
             }
 
+            let resolvedTitle = metadata.title ?? deriveTitleFromFilename(url)
             let track = Track(
                 id: UUID(),
                 stableID: stableID,
@@ -225,7 +232,7 @@ final class MusicIndexer: ObservableObject {
                 filename: url.lastPathComponent,
                 rootBookmarkID: rootID,
                 fileBookmark: nil,
-                title: metadata.title ?? deriveTitleFromFilename(url),
+                title: resolvedTitle,
                 artist: metadata.artist,
                 album: metadata.album,
                 albumArtist: metadata.albumArtist,
@@ -237,7 +244,8 @@ final class MusicIndexer: ObservableObject {
                 fileSize: fileSize,
                 fileFormat: fileFormat,
                 artworkPath: artworkPath,
-                fileModified: mtime
+                fileModified: mtime,
+                language: TrackLanguage.classify(title: resolvedTitle, artist: metadata.artist)
             )
             tracks.append(track)
             if priorByID[stableID] == nil { added += 1 } else { updated += 1 }

--- a/HarmonIQ/Models/Track.swift
+++ b/HarmonIQ/Models/Track.swift
@@ -30,10 +30,24 @@ struct Track: Identifiable, Codable, Hashable {
     /// indexed by a build before issue #55). The next reindex treats nil
     /// as "unknown — re-extract once" so the field gets populated.
     var fileModified: Date?
+    /// Heuristic language bucket (issue #86). Computed at index time from
+    /// `title + artist`. Optional so library.json files written before
+    /// language classification existed decode cleanly — those rows get
+    /// classified on the next index run, or via the Settings →
+    /// "Reclassify all tracks" action.
+    var language: TrackLanguage?
 
     var displayTitle: String { title.isEmpty ? filename : title }
     var displayArtist: String { (artist?.nilIfBlank) ?? (albumArtist?.nilIfBlank) ?? "Unknown Artist" }
     var displayAlbum: String { (album?.nilIfBlank) ?? "Unknown Album" }
+
+    /// Effective language bucket. Falls back to `.others` for rows that
+    /// haven't been classified yet (legacy library.json files written
+    /// before issue #86). Use this in views; the optional `language`
+    /// field is only for persistence.
+    var effectiveLanguage: TrackLanguage {
+        language ?? TrackLanguage.classify(title: title, artist: artist)
+    }
 
     var folderPath: [String] { Array(relativePath.dropLast()) }
     var folderKey: String { folderPath.joined(separator: "/") }

--- a/HarmonIQ/Models/TrackLanguage.swift
+++ b/HarmonIQ/Models/TrackLanguage.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+/// Language bucket used by the Library → Language browse view (issue #86).
+///
+/// Classification is heuristic — based on the characters in `title + artist`.
+/// Computed once at index time and persisted on `Track.language`. Tradeoffs
+/// documented on `classify(title:artist:)` below.
+enum TrackLanguage: String, CaseIterable, Codable, Hashable {
+    /// Title or artist contains any character in the CJK Unified Ideographs
+    /// blocks. Known v1 limitation: this conflates Japanese kanji and
+    /// Korean hanja with Chinese — files written in those scripts ALSO
+    /// land here. Sub-bucketing is explicitly out of scope.
+    case chinese
+    /// All letters in `title + artist` are basic Latin (a-z / A-Z), with
+    /// digits and punctuation tolerated. The default bucket for English-
+    /// language tracks.
+    case english
+    /// Everything else: Cyrillic, Arabic, Thai, hiragana/katakana-only,
+    /// hangul-only, accented Latin (French / Spanish / German), and
+    /// instrumental tracks whose title is empty / numeric / symbol-only.
+    case others
+
+    /// Sort order on the Language hub. Chinese first, English second,
+    /// Others last — matches the order in the issue body.
+    static let displayOrder: [TrackLanguage] = [.chinese, .english, .others]
+
+    var displayName: String {
+        switch self {
+        case .chinese: return "Chinese"
+        case .english: return "English"
+        case .others:  return "Others"
+        }
+    }
+
+    /// SF Symbol for the Library row. Picked to be visually distinct
+    /// from other Browse rows (artists, albums, folders).
+    var iconName: String {
+        switch self {
+        case .chinese: return "character.book.closed"
+        case .english: return "textformat"
+        case .others:  return "globe"
+        }
+    }
+
+    /// Heuristic classification. Pure function — safe to call from any
+    /// actor. Empty/whitespace-only and symbol-only inputs (i.e.
+    /// instrumentals where neither tag was set) classify as `.others`,
+    /// which the issue spec calls out by name.
+    static func classify(title: String?, artist: String?) -> TrackLanguage {
+        let combined = ((title ?? "") + " " + (artist ?? ""))
+        // Strip whitespace; the rule "all letters basic Latin → English"
+        // would otherwise be skewed by stray whitespace that contains
+        // no letters.
+        let trimmed = combined.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if containsCJK(trimmed) { return .chinese }
+
+        // After excluding CJK, decide if there's enough Latin signal to
+        // call it English. We look at letters only (ignoring digits and
+        // punctuation): if at least one letter exists AND every letter
+        // is basic Latin a-z / A-Z, it's English. This means a track
+        // whose title is "01 - Untitled" (no letters, just digits +
+        // dashes) lands in Others, which matches the issue's
+        // "pure music … instrumental" intent.
+        var hasLetter = false
+        var allBasicLatin = true
+        for scalar in trimmed.unicodeScalars {
+            if isLetter(scalar) {
+                hasLetter = true
+                if !isBasicLatinLetter(scalar) {
+                    allBasicLatin = false
+                    break
+                }
+            }
+        }
+        if hasLetter && allBasicLatin { return .english }
+        return .others
+    }
+
+    // MARK: - Character class helpers
+
+    /// CJK Unified Ideographs blocks. The list here is the practical set
+    /// of ranges actually used by Chinese / Japanese kanji / Korean
+    /// hanja text — Extension B+ (the Plane 2 ranges) are rare enough
+    /// that omitting them costs nothing and keeps this fast.
+    private static let cjkRanges: [ClosedRange<UInt32>] = [
+        0x3400...0x4DBF,    // CJK Unified Ideographs Extension A
+        0x4E00...0x9FFF,    // CJK Unified Ideographs (the common one)
+        0xF900...0xFAFF,    // CJK Compatibility Ideographs
+        0x20000...0x2A6DF,  // Extension B
+        0x2A700...0x2B73F,  // Extension C
+        0x2B740...0x2B81F,  // Extension D
+    ]
+
+    private static func containsCJK(_ s: String) -> Bool {
+        for scalar in s.unicodeScalars {
+            let v = scalar.value
+            for r in cjkRanges where r.contains(v) { return true }
+        }
+        return false
+    }
+
+    private static func isLetter(_ scalar: Unicode.Scalar) -> Bool {
+        scalar.properties.isAlphabetic
+    }
+
+    private static func isBasicLatinLetter(_ scalar: Unicode.Scalar) -> Bool {
+        let v = scalar.value
+        return (0x41...0x5A).contains(v) || (0x61...0x7A).contains(v)
+    }
+}

--- a/HarmonIQ/Persistence/DriveLibraryStore.swift
+++ b/HarmonIQ/Persistence/DriveLibraryStore.swift
@@ -44,6 +44,11 @@ enum DriveLibraryStore {
         /// by builds before issue #55 still decode; treated as "unknown,
         /// re-extract once" by the indexer to backfill on next scan.
         var fileModified: Date?
+        /// Heuristic language bucket (issue #86). Optional so library.json
+        /// files written before classification existed decode cleanly — a
+        /// nil row is reclassified on the next index run, or via the
+        /// Settings "Reclassify all tracks" action.
+        var language: String?
     }
 
     struct DrivePlaylistsFile: Codable {
@@ -153,7 +158,8 @@ enum DriveLibraryStore {
             fileSize: dt.fileSize,
             fileFormat: dt.fileFormat,
             artworkPath: dt.artworkPath,
-            fileModified: dt.fileModified
+            fileModified: dt.fileModified,
+            language: dt.language.flatMap { TrackLanguage(rawValue: $0) }
         )
     }
 
@@ -174,7 +180,8 @@ enum DriveLibraryStore {
             fileSize: t.fileSize,
             fileFormat: t.fileFormat,
             artworkPath: t.artworkPath,
-            fileModified: t.fileModified
+            fileModified: t.fileModified,
+            language: t.language?.rawValue
         )
     }
 

--- a/HarmonIQ/Persistence/LibraryStore.swift
+++ b/HarmonIQ/Persistence/LibraryStore.swift
@@ -775,6 +775,59 @@ final class LibraryStore: ObservableObject {
         }
     }
 
+    // MARK: - Language (issue #86)
+
+    /// Track count per language bucket. Used by the Library hub to render
+    /// counts next to each row.
+    var languageCounts: [TrackLanguage: Int] {
+        var out: [TrackLanguage: Int] = [:]
+        for t in tracks {
+            out[t.effectiveLanguage, default: 0] += 1
+        }
+        return out
+    }
+
+    /// Tracks classified into `bucket`, sorted by display title. The
+    /// language hub passes the result straight to a list view.
+    func tracks(forLanguage bucket: TrackLanguage) -> [Track] {
+        tracks.filter { $0.effectiveLanguage == bucket }
+            .sorted { lhs, rhs in
+                if lhs.displayArtist != rhs.displayArtist {
+                    return lhs.displayArtist.localizedStandardCompare(rhs.displayArtist) == .orderedAscending
+                }
+                return lhs.displayTitle.localizedStandardCompare(rhs.displayTitle) == .orderedAscending
+            }
+    }
+
+    /// Reclassifies every track on every drive in-place and persists. Used
+    /// when the user has already-indexed drives from a build before issue
+    /// #86 — saves the user from running a full reindex just to get
+    /// language buckets populated. Returns the count of rows whose
+    /// classification actually changed (purely for status display).
+    @discardableResult
+    func reclassifyAllLanguages() -> Int {
+        var changed = 0
+        var rebuilt: [Track] = []
+        rebuilt.reserveCapacity(tracks.count)
+        for t in tracks {
+            let bucket = TrackLanguage.classify(title: t.title, artist: t.artist)
+            if t.language != bucket {
+                changed += 1
+                var copy = t
+                copy.language = bucket
+                rebuilt.append(copy)
+            } else {
+                rebuilt.append(t)
+            }
+        }
+        // Persist per drive so each library.json is rewritten once.
+        let perRoot = Dictionary(grouping: rebuilt, by: { $0.rootBookmarkID })
+        for (rootID, perRootTracks) in perRoot {
+            replaceTracks(forRoot: rootID, with: perRootTracks)
+        }
+        return changed
+    }
+
     func search(_ query: String) -> [Track] {
         let q = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard !q.isEmpty else { return [] }

--- a/HarmonIQ/Views/LanguageView.swift
+++ b/HarmonIQ/Views/LanguageView.swift
@@ -1,0 +1,96 @@
+import SwiftUI
+
+/// Library → Language hub (issue #86). Three buckets — Chinese / English /
+/// Others — derived from a heuristic title/artist scan at index time.
+/// Tapping a row drills into a filtered track list.
+struct LanguageView: View {
+    @EnvironmentObject var library: LibraryStore
+
+    var body: some View {
+        let counts = library.languageCounts
+        Group {
+            if library.tracks.isEmpty {
+                EmptyStateView(title: "No tracks",
+                               message: "Index a music drive to browse by language.",
+                               systemImage: "globe")
+            } else {
+                List {
+                    Section {
+                        ForEach(TrackLanguage.displayOrder, id: \.self) { bucket in
+                            NavigationLink {
+                                LanguageDetailView(bucket: bucket)
+                            } label: {
+                                WinampNavRow(title: bucket.displayName.uppercased(),
+                                             icon: bucket.iconName,
+                                             count: counts[bucket] ?? 0)
+                            }
+                        }
+                        .listRowBackground(Color.clear)
+                    } header: {
+                        SectionHeader("// LANGUAGE")
+                    } footer: {
+                        Text("Heuristic classification based on title and artist text. CJK characters map to Chinese (note: Japanese kanji and Korean hanja also land here in v1). Pure Latin maps to English. Anything else — accented Latin, hiragana/katakana-only, hangul-only, Cyrillic, Arabic, instrumentals with empty or numeric titles — lands in Others.")
+                            .font(WinampTheme.lcdFont(size: 10))
+                            .foregroundStyle(WinampTheme.lcdDim)
+                    }
+                }
+                .scrollContentBackground(.hidden)
+                .background(Color.clear)
+            }
+        }
+        .navigationTitle("Language")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+private struct LanguageDetailView: View {
+    let bucket: TrackLanguage
+    @EnvironmentObject var library: LibraryStore
+    @EnvironmentObject var player: AudioPlayerManager
+
+    var body: some View {
+        let tracks = library.tracks(forLanguage: bucket)
+        Group {
+            if tracks.isEmpty {
+                EmptyStateView(title: "No \(bucket.displayName.lowercased()) tracks",
+                               message: bucket == .others
+                                   ? "Pure-instrumental, accented Latin, hangul, hiragana, Cyrillic and other scripts land here."
+                                   : "Nothing classified as \(bucket.displayName) yet.",
+                               systemImage: bucket.iconName)
+            } else {
+                List {
+                    ForEach(tracks) { track in
+                        TrackRow(track: track, showAlbum: true)
+                            .onTapGesture {
+                                player.play(track: track, in: tracks)
+                            }
+                            .swipeActions {
+                                AddToPlaylistMenuButton(trackIDs: [track.stableID])
+                            }
+                    }
+                }
+                .scrollContentBackground(.hidden)
+                .background(Color.clear)
+            }
+        }
+        .navigationTitle(bucket.displayName)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Menu {
+                    Button {
+                        player.playAll(tracks, startAt: 0)
+                    } label: { Label("Play All", systemImage: "play") }
+                    Button {
+                        player.isShuffleEnabled = true
+                        var shuffled = tracks
+                        shuffled.shuffle()
+                        player.playAll(shuffled, startAt: 0)
+                    } label: { Label("Shuffle", systemImage: "shuffle") }
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                }
+            }
+        }
+    }
+}

--- a/HarmonIQ/Views/LibraryView.swift
+++ b/HarmonIQ/Views/LibraryView.swift
@@ -41,6 +41,11 @@ struct LibraryView: View {
                         WinampNavRow(title: "ALBUMS", icon: "square.stack", count: library.allAlbums.count)
                     }
                     NavigationLink {
+                        LanguageView()
+                    } label: {
+                        WinampNavRow(title: "LANGUAGE", icon: "globe", count: TrackLanguage.allCases.count)
+                    }
+                    NavigationLink {
                         FoldersView()
                     } label: {
                         WinampNavRow(title: "FOLDERS", icon: "folder", count: library.roots.count)

--- a/HarmonIQ/Views/SettingsView.swift
+++ b/HarmonIQ/Views/SettingsView.swift
@@ -20,6 +20,7 @@ struct SettingsView: View {
     @State private var showPicker = false
     @State private var bulkConfirmRoot: LibraryRoot?
     @State private var rebuildConfirmRoot: LibraryRoot?
+    @State private var reclassifyStatus: String = ""
 
     var body: some View {
         List {
@@ -118,10 +119,24 @@ struct SettingsView: View {
                     }
                     .disabled(indexer.isIndexing)
                 }
+                Button {
+                    let changed = library.reclassifyAllLanguages()
+                    reclassifyStatus = changed == 0
+                        ? "Languages already up to date — \(library.tracks.count) track(s) checked."
+                        : "Reclassified \(changed) of \(library.tracks.count) track(s)."
+                } label: {
+                    Label("Reclassify all tracks by language", systemImage: "globe")
+                }
+                .disabled(library.tracks.isEmpty)
+                if !reclassifyStatus.isEmpty {
+                    Text(reclassifyStatus)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             } header: {
                 Text("Maintenance")
             } footer: {
-                Text("Wipes the drive's library.json and runs a fresh full scan. Use this if the album list is duplicated or has stale entries (issue #88). Playlists survive as long as the audio files are still at the same paths on the drive. Favorites, smart playlists, and roots.json are preserved.")
+                Text("Rebuild wipes the drive's library.json and runs a fresh full scan — use it if the album list is duplicated or has stale entries (issue #88). Reclassify recomputes the Chinese / English / Others bucket on every track without re-reading audio (issue #86). Playlists, favorites, and smart playlists are preserved by both actions.")
             }
 
             Section {


### PR DESCRIPTION
## Linked issue

Closes #86

## Summary

- New `TrackLanguage` enum (chinese / english / others) with a pure-function `classify(title:artist:)`.
- Persisted on `Track.language` and `DriveTrack.language` as an optional, so existing library.json files decode unchanged.
- `MusicIndexer.runIndex` classifies on every fresh row AND backfills nil values on the reuse path — incremental rescans patch older library.json files for free.
- New Library → Language hub rendered as a three-row WinampNavRow list with bucket counts; tap drills into the filtered tracks (Play All / Shuffle in toolbar).
- Settings → Maintenance → "Reclassify all tracks by language" recomputes buckets in-memory without touching audio, for users whose drives were already indexed.

## v1 limitations called out in the issue

- CJK detection conflates Japanese kanji and Korean hanja with Chinese (acceptable per the issue body — flag in PR description).
- No `TLAN` ID3 frame reading, no per-track manual override, no sub-buckets. All deferred per the issue's "out of scope" list.

## Test plan (PR-specific)

- [x] Library → Language renders 3 rows in order: Chinese, English, Others.
- [x] Track with all-CJK title classifies as Chinese.
- [x] Track with empty/numeric title classifies as Others (the "pure music" intent).
- [x] Reclassify action runs against an already-indexed library and reports a status string.

## Regression check

- [x] **A. Build + launch** (iPhone 17 simulator)
- [x] B. Library + drive flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)