### PR TITLE
Artists browse: visual grid with representative covers (#89)

### DIFF
--- a/HarmonIQ/Persistence/LibraryStore.swift
+++ b/HarmonIQ/Persistence/LibraryStore.swift
@@ -669,6 +669,86 @@ final class LibraryStore: ObservableObject {
         tracks.filter { $0.displayArtist == artist }
     }
 
+    /// Representative track for an artist (issue #89). Picks the track from
+    /// the album the artist has the most tracks on; ties break by album
+    /// name (localized standard, ascending). The returned track's
+    /// `artworkPath` (if set) is what `ArtworkView` will render in the
+    /// Artists grid. Result is cached per `tracks` snapshot so scrolling
+    /// the grid doesn't recompute on every cell read.
+    func representativeTrack(forArtist artist: String) -> Track? {
+        if let cached = artistRepresentativeCache, cached.snapshotID == tracksSnapshotID {
+            return cached.map[artist]
+        }
+        rebuildArtistRepresentativeCache()
+        return artistRepresentativeCache?.map[artist]
+    }
+
+    private struct ArtistRepresentativeCache {
+        let snapshotID: Int
+        let map: [String: Track]
+    }
+
+    private var artistRepresentativeCache: ArtistRepresentativeCache?
+
+    /// Cheap snapshot identity for the tracks array so the cache can
+    /// invalidate when tracks change. Uses count + first/last stableID
+    /// hashes — collisions would have to be carefully constructed to
+    /// matter here, and the worst case is one extra recomputation.
+    private var tracksSnapshotID: Int {
+        var hasher = Hasher()
+        hasher.combine(tracks.count)
+        hasher.combine(tracks.first?.stableID ?? "")
+        hasher.combine(tracks.last?.stableID ?? "")
+        return hasher.finalize()
+    }
+
+    private func rebuildArtistRepresentativeCache() {
+        // Group every track by displayArtist, then within each group find
+        // the album with the most tracks. Pick the first track from that
+        // album (sorted by disc/track/title) so it's deterministic across
+        // app launches with the same library.
+        var byArtist: [String: [Track]] = [:]
+        for t in tracks {
+            byArtist[t.displayArtist, default: []].append(t)
+        }
+        var map: [String: Track] = [:]
+        map.reserveCapacity(byArtist.count)
+        for (artist, group) in byArtist {
+            // "Various Artists" entries shouldn't claim the first
+            // compilation cover by default — issue #89's compilation
+            // handling note. Skip the lookup so the tile falls back to
+            // the placeholder, which reads more honestly.
+            if artist.caseInsensitiveCompare(Self.variousArtistsLabel) == .orderedSame {
+                continue
+            }
+            // Album frequency table.
+            var albumCounts: [String: Int] = [:]
+            for t in group {
+                albumCounts[t.displayAlbum, default: 0] += 1
+            }
+            // Tiebreak alphabetically (localized) so the choice is stable.
+            let chosenAlbum: String? = albumCounts
+                .sorted { lhs, rhs in
+                    if lhs.value != rhs.value { return lhs.value > rhs.value }
+                    return lhs.key.localizedStandardCompare(rhs.key) == .orderedAscending
+                }.first?.key
+            guard let chosen = chosenAlbum else { continue }
+            // Pick the deterministic first track of the chosen album.
+            // Prefer one that actually has artwork — saves rendering
+            // a placeholder when at least one cover exists for this
+            // artist somewhere on this album.
+            let albumTracks = group.filter { $0.displayAlbum == chosen }
+                .sorted { lhs, rhs in
+                    if let l = lhs.discNumber, let r = rhs.discNumber, l != r { return l < r }
+                    if let l = lhs.trackNumber, let r = rhs.trackNumber, l != r { return l < r }
+                    return lhs.displayTitle.localizedStandardCompare(rhs.displayTitle) == .orderedAscending
+                }
+            let withArt = albumTracks.first(where: { $0.artworkPath != nil })
+            map[artist] = withArt ?? albumTracks.first
+        }
+        artistRepresentativeCache = ArtistRepresentativeCache(snapshotID: tracksSnapshotID, map: map)
+    }
+
     /// Identifier for a single album row in the Albums view. Two flavours:
     ///
     /// - **Single-artist** (`isCompilation == false`): the conventional

--- a/HarmonIQ/Views/ArtistsView.swift
+++ b/HarmonIQ/Views/ArtistsView.swift
@@ -1,7 +1,18 @@
 import SwiftUI
 
+/// Artists browse view (issue #89). Visual grid mirroring `AlbumsView` —
+/// each tile shows a representative album cover for the artist (the album
+/// they have the most tracks on, alphabetic tiebreak). Artists with no
+/// artwork get a Winamp-themed placeholder.
+///
+/// v1 is offline-pure: no network fetches. Network-fetched artist photos
+/// are filed as a follow-up.
 struct ArtistsView: View {
     @EnvironmentObject var library: LibraryStore
+
+    private let columns: [GridItem] = [
+        GridItem(.adaptive(minimum: 150), spacing: 16)
+    ]
 
     var body: some View {
         Group {
@@ -10,26 +21,88 @@ struct ArtistsView: View {
                                message: "Index a music drive to see artists.",
                                systemImage: "music.mic")
             } else {
-                List(library.allArtists, id: \.self) { artist in
-                    NavigationLink {
-                        ArtistDetailView(artist: artist)
-                    } label: {
-                        HStack {
-                            Image(systemName: "person.fill")
-                                .foregroundStyle(.secondary)
-                                .frame(width: 32)
-                            Text(artist)
-                            Spacer()
-                            Text("\(library.tracks(byArtist: artist).count)")
-                                .foregroundStyle(.secondary)
-                                .font(.caption.monospacedDigit())
+                ScrollView {
+                    LazyVGrid(columns: columns, spacing: 20) {
+                        ForEach(library.allArtists, id: \.self) { artist in
+                            NavigationLink {
+                                ArtistDetailView(artist: artist)
+                            } label: {
+                                ArtistCard(artist: artist)
+                            }
+                            .buttonStyle(.plain)
                         }
                     }
+                    .padding(16)
                 }
             }
         }
         .navigationTitle("Artists")
         .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+private struct ArtistCard: View {
+    let artist: String
+    @EnvironmentObject var library: LibraryStore
+
+    var body: some View {
+        let representative = library.representativeTrack(forArtist: artist)
+        let trackCount = library.tracks(byArtist: artist).count
+        VStack(alignment: .leading, spacing: 6) {
+            // Use a circular crop for artist tiles to visually distinguish
+            // them from album tiles (square). When no artwork at all is
+            // attached to the artist's tracks, render the Winamp-themed
+            // placeholder glyph.
+            ArtistTile(track: representative, size: 150)
+                .frame(maxWidth: .infinity)
+            Text(artist)
+                .font(.subheadline.weight(.semibold))
+                .lineLimit(1)
+            Text("\(trackCount) track\(trackCount == 1 ? "" : "s")")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+    }
+}
+
+/// Circular artist tile. Uses the representative track's artwork when one
+/// exists; otherwise renders a microphone glyph in lcdGlow on the panel
+/// gradient — same design language as `ArtworkView`'s placeholder, but
+/// shaped as a circle to read as a "person" rather than an "album."
+private struct ArtistTile: View {
+    let track: Track?
+    let size: CGFloat
+
+    var body: some View {
+        Group {
+            if let image = loadImage() {
+                Image(uiImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+            } else {
+                ZStack {
+                    WinampTheme.panelGradient
+                    Image(systemName: "music.mic")
+                        .font(.system(size: size * 0.42, weight: .bold))
+                        .foregroundStyle(WinampTheme.lcdGlow.opacity(0.7))
+                        .shadow(color: WinampTheme.lcdGlow.opacity(0.4), radius: 2)
+                }
+            }
+        }
+        .frame(width: size, height: size)
+        .clipShape(Circle())
+        .overlay(
+            Circle()
+                .strokeBorder(WinampTheme.bevelLight.opacity(0.35), lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.25), radius: 6, y: 3)
+    }
+
+    private func loadImage() -> UIImage? {
+        guard let path = track?.artworkPath else { return nil }
+        let url = LibraryStore.shared.artworkDirectory.appendingPathComponent(path)
+        return UIImage(contentsOfFile: url.path)
     }
 }
 


### PR DESCRIPTION
## Linked issue

Closes #89

## Summary

- `ArtistsView` switches from a plain list to a `LazyVGrid` mirroring `AlbumsView`. Tile shape is a circle (vs `AlbumsView`'s rounded rectangle) to read as "person" rather than "album."
- New `LibraryStore.representativeTrack(forArtist:)` picks the album the artist has the most tracks on (alphabetic tiebreak), then the deterministic first track that has artwork. Cached per tracks-snapshot identity so grid scroll is cheap.
- Artists with no artwork on any of their albums get a Winamp-themed `music.mic` placeholder in `lcdGlow` on the panel gradient — same design language as the existing artwork placeholder.
- "Various Artists" entries skip the cover lookup and fall back to the placeholder, per the issue's compilation note.

## Out of scope (per issue body)

- Network-fetched artist photos (option 2 in the issue) — left for a follow-up that would mirror the #74 opt-in privacy pattern.
- Manually-assigned artist images.

## Test plan (PR-specific)

- [x] Library → Artists renders a grid; each tile shows a circular cover.
- [x] An artist with multiple albums uses the cover from the album with the most tracks.
- [x] An artist with zero artwork on any track gets the placeholder tile.
- [x] "Various Artists" displays the placeholder, not a compilation cover.

## Regression check

- [x] **A. Build + launch** (iPhone 17 simulator)
- [x] B. Library + drive flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)