### PR TITLE
Opt-in artist-photo fetcher (closes #93)

### DIFF
--- a/HarmonIQ.xcodeproj/project.pbxproj
+++ b/HarmonIQ.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		09DB5BB6958F7981EAFF5EED /* SmartPlayAI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A3E5FF59C499E1F16218AA /* SmartPlayAI.swift */; };
 		116A7F3DD4FF063CD5776F50 /* LiveActivityController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2650366DAD3EEB077B33CD /* LiveActivityController.swift */; };
 		16F8F24D50C9EB96562011DC /* SmartPlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = A31A65F1BCE09BD374018CC4 /* SmartPlay.swift */; };
+		345F521B16227886D1F5DC7D /* ArtistPhotoFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14ED2595E48145654B518959 /* ArtistPhotoFetcher.swift */; };
 		3623E19150C55CECDF8DF6BE /* HarmonIQActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4F2B572BEA8AA004255D82 /* HarmonIQActivityAttributes.swift */; };
 		378FEA2A2125F0710167C4EE /* ScrollingBitmapText.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB566E7DBDC9F95DA534869C /* ScrollingBitmapText.swift */; };
 		3A5F09869BC9EA7F4DC88B35 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D6EA2A86E18C3306B3A4BFC /* ContentView.swift */; };
@@ -97,6 +98,7 @@
 
 /* Begin PBXFileReference section */
 		03C45ED4E273D5CD36352156 /* SleepTimerViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepTimerViews.swift; sourceTree = "<group>"; };
+		14ED2595E48145654B518959 /* ArtistPhotoFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistPhotoFetcher.swift; sourceTree = "<group>"; };
 		15226D22B73C8F0CE0719B80 /* VisualizerSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualizerSettingsView.swift; sourceTree = "<group>"; };
 		1747349698811EB8ADA561A3 /* EqualizerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EqualizerManager.swift; sourceTree = "<group>"; };
 		21D6E4A738A357E6A860D0E0 /* ArtistsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistsView.swift; sourceTree = "<group>"; };
@@ -211,6 +213,7 @@
 		562B9DDB1FC012BBB793F975 /* Indexer */ = {
 			isa = PBXGroup;
 			children = (
+				14ED2595E48145654B518959 /* ArtistPhotoFetcher.swift */,
 				99DCB9BA8F0F6EA560429A13 /* ArtworkFetcher.swift */,
 				F53B7620084258E7F659C7D7 /* MetadataExtractor.swift */,
 				9D861E89EB0B0713F92113EE /* MusicIndexer.swift */,
@@ -484,6 +487,7 @@
 				E1D2A557F273963F3ABFCFC5 /* AllTracksView.swift in Sources */,
 				4BAC40B449B110A162FC0AE2 /* AnthropicClient.swift in Sources */,
 				4BFD5B83D404C76871760396 /* AppleIntelligenceClient.swift in Sources */,
+				345F521B16227886D1F5DC7D /* ArtistPhotoFetcher.swift in Sources */,
 				DA3451E853523F3F3794A302 /* ArtistsView.swift in Sources */,
 				FA7DA3571AC5AD9473009C9C /* ArtworkFetcher.swift in Sources */,
 				DCF4418A459E115EF770E6D9 /* AudioPlayerManager.swift in Sources */,

--- a/HarmonIQ/Indexer/ArtistPhotoFetcher.swift
+++ b/HarmonIQ/Indexer/ArtistPhotoFetcher.swift
@@ -1,0 +1,496 @@
+import Foundation
+import Combine
+import CryptoKit
+import Network
+import UIKit
+
+/// Opt-in online artist-photo fetcher (issue #93).
+///
+/// Sibling to `ArtworkFetcher`. Looks up an artist's MusicBrainz ID, then
+/// resolves the Wikidata entity's `P18` image (a Wikimedia Commons file) and
+/// writes the result to
+/// `<DriveRoot>/HarmonIQ/Artwork/artists/<sha1(artistName)>.jpg`, with the
+/// same security-scoped bookmark dance album art uses. The local sandbox
+/// gets a mirrored copy so views can read images without holding scope.
+///
+/// Privacy: like `ArtworkFetcher`, this is off by default. The toggle in
+/// Settings is separate from the album-art toggle so users can opt into one
+/// and not the other. When off, every public entry point is a no-op — no
+/// network traffic of any kind.
+///
+/// Reuse: this fetcher *shares* the `MusicBrainzRateLimiter` instance owned
+/// by `ArtworkFetcher.shared` so artist + album lookups can't burst-hit
+/// MusicBrainz collectively. The Wikidata + Wikimedia Commons hops are not
+/// rate-limited beyond polite back-off; both are CDN-fronted and tolerate
+/// modest concurrency, but we still serialize the bulk refresh through the
+/// same rate-limited gate to keep the per-IP profile predictable.
+///
+/// Threading mirrors `ArtworkFetcher`: `@MainActor` for published progress
+/// and writes to `LibraryStore`; network + IO hop to detached tasks.
+@MainActor
+final class ArtistPhotoFetcher: ObservableObject {
+    static let shared = ArtistPhotoFetcher()
+
+    // MARK: - User preference
+
+    private static let enabledDefaultsKey = "ArtistPhotoFetcher.onlineEnabled"
+
+    /// User-visible toggle. Off by default. When false, every public entry
+    /// point on this type is a no-op.
+    @Published var isOnlineFetchEnabled: Bool {
+        didSet {
+            UserDefaults.standard.set(isOnlineFetchEnabled, forKey: Self.enabledDefaultsKey)
+        }
+    }
+
+    // MARK: - Bulk refresh status (drives the Settings UI)
+
+    @Published private(set) var isRefreshing: Bool = false
+    @Published private(set) var refreshStatusMessage: String = ""
+    @Published private(set) var refreshProgress: Double = 0
+    @Published private(set) var refreshProcessed: Int = 0
+    @Published private(set) var refreshTotal: Int = 0
+
+    private var refreshTask: Task<Void, Never>?
+
+    // MARK: - In-flight + negative dedupe
+
+    /// Artist hashes (sha1 of normalized artist name) currently being
+    /// fetched, so opening Artists view + a manual refresh can't issue two
+    /// simultaneous network round-trips for the same artist.
+    private var inFlight: Set<String> = []
+    /// Artist hashes that returned no usable photo this session — either
+    /// MusicBrainz had no MBID, the MBID had no Wikidata link, or the
+    /// Wikidata entity had no `P18`. Cleared on relaunch so an upstream
+    /// correction lets the next session retry.
+    private var negativeCache: Set<String> = []
+
+    // MARK: - Reachability
+
+    private let pathMonitor = NWPathMonitor()
+    private var pathMonitorStarted = false
+    private var lastKnownPath: NWPath?
+
+    // MARK: - Rate limiter (shared)
+
+    /// Shares `ArtworkFetcher`'s rate limiter so artist + album lookups
+    /// can't burst-hit MusicBrainz collectively.
+    private let rateLimiter: MusicBrainzRateLimiter
+
+    private init() {
+        self.isOnlineFetchEnabled = UserDefaults.standard.bool(forKey: Self.enabledDefaultsKey)
+        self.rateLimiter = ArtworkFetcher.shared.musicBrainzRateLimiter
+    }
+
+    // MARK: - Reachability gate
+
+    private func isOnline() -> Bool {
+        if !pathMonitorStarted {
+            pathMonitor.pathUpdateHandler = { [weak self] path in
+                Task { @MainActor [weak self] in
+                    self?.lastKnownPath = path
+                }
+            }
+            pathMonitor.start(queue: DispatchQueue(label: "net.leochen.harmoniq.artistphoto.path"))
+            pathMonitorStarted = true
+            // Same optimistic-on-cold-start behavior as ArtworkFetcher.
+            return true
+        }
+        guard let path = lastKnownPath else { return true }
+        return path.status == .satisfied
+    }
+
+    // MARK: - Public API
+
+    /// Fire-and-forget: if no local photo exists for this artist, queue a
+    /// fetch attempt. Safe to call from view code — never blocks. Caller
+    /// supplies `rootBookmarkID` so we know where to persist the JPEG.
+    func fetchIfMissing(artist: String, rootBookmarkID: UUID) {
+        guard isOnlineFetchEnabled else { return }
+        let trimmed = artist.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              trimmed.lowercased() != "unknown",
+              trimmed.caseInsensitiveCompare(LibraryStore.variousArtistsLabel) != .orderedSame
+        else { return }
+
+        let hash = Self.sha1Hex(trimmed)
+
+        // Already have local photo for this artist → nothing to do.
+        let localTarget = LibraryStore.shared.artistPhotoDirectory.appendingPathComponent("\(hash).jpg")
+        if FileManager.default.fileExists(atPath: localTarget.path) { return }
+
+        if negativeCache.contains(hash) { return }
+        if inFlight.contains(hash) { return }
+
+        if !isOnline() { return }
+
+        inFlight.insert(hash)
+        Task.detached(priority: .utility) { [weak self] in
+            await self?.runFetch(artistHash: hash,
+                                 artist: trimmed,
+                                 rootBookmarkID: rootBookmarkID)
+        }
+    }
+
+    /// Bulk pass over a drive: walks every artist that lacks a photo and
+    /// tries to fill it. Serialized through the shared MusicBrainz rate
+    /// limiter so we never exceed 1 req/sec.
+    func refreshMissingArtistPhotos(for root: LibraryRoot) {
+        guard isOnlineFetchEnabled else { return }
+        guard !isRefreshing else { return }
+
+        let rootID = root.id
+        let allTracks = LibraryStore.shared.tracks.filter { $0.rootBookmarkID == rootID }
+        var seenArtists: Set<String> = []
+        var queue: [(hash: String, artist: String)] = []
+        let localCache = LibraryStore.shared.artistPhotoDirectory
+        for t in allTracks {
+            let artist = t.displayArtist
+            if seenArtists.contains(artist) { continue }
+            seenArtists.insert(artist)
+            let trimmed = artist.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty { continue }
+            if trimmed.lowercased() == "unknown" { continue }
+            if trimmed.caseInsensitiveCompare(LibraryStore.variousArtistsLabel) == .orderedSame { continue }
+            let hash = Self.sha1Hex(trimmed)
+            let local = localCache.appendingPathComponent("\(hash).jpg")
+            if FileManager.default.fileExists(atPath: local.path) { continue }
+            if negativeCache.contains(hash) { continue }
+            queue.append((hash, trimmed))
+        }
+
+        if queue.isEmpty {
+            refreshStatusMessage = "No artists missing photos on \(root.displayName)."
+            return
+        }
+
+        if !isOnline() {
+            refreshStatusMessage = "Offline — try again when you have a connection."
+            return
+        }
+
+        isRefreshing = true
+        refreshTotal = queue.count
+        refreshProcessed = 0
+        refreshProgress = 0
+        refreshStatusMessage = "Fetching photos for \(queue.count) artists…"
+
+        refreshTask = Task.detached(priority: .utility) { [weak self] in
+            await self?.runBulkRefresh(queue: queue, rootBookmarkID: rootID, rootName: root.displayName)
+        }
+    }
+
+    func cancelRefresh() {
+        refreshTask?.cancel()
+        refreshTask = nil
+        isRefreshing = false
+        refreshStatusMessage = "Refresh cancelled."
+    }
+
+    // MARK: - Internals
+
+    nonisolated private func runFetch(artistHash: String,
+                                      artist: String,
+                                      rootBookmarkID: UUID) async {
+        defer {
+            Task { @MainActor [weak self] in
+                self?.inFlight.remove(artistHash)
+            }
+        }
+        let result = await Self.lookupAndDownload(artist: artist, rateLimiter: rateLimiter)
+        guard let imageData = result else {
+            await MainActor.run {
+                _ = self.negativeCache.insert(artistHash)
+            }
+            return
+        }
+        await MainActor.run {
+            self.persistDownloadedPhoto(imageData,
+                                        artistHash: artistHash,
+                                        rootBookmarkID: rootBookmarkID)
+        }
+    }
+
+    nonisolated private func runBulkRefresh(queue: [(hash: String, artist: String)],
+                                            rootBookmarkID: UUID,
+                                            rootName: String) async {
+        var succeeded = 0
+        var processed = 0
+        for entry in queue {
+            if Task.isCancelled { break }
+            let result = await Self.lookupAndDownload(artist: entry.artist, rateLimiter: rateLimiter)
+            processed += 1
+            if let data = result {
+                succeeded += 1
+                let localProcessed = processed
+                let localSucceeded = succeeded
+                let localTotal = queue.count
+                await MainActor.run {
+                    self.persistDownloadedPhoto(data,
+                                                artistHash: entry.hash,
+                                                rootBookmarkID: rootBookmarkID)
+                    self.refreshProcessed = localProcessed
+                    self.refreshProgress = Double(localProcessed) / Double(localTotal)
+                    self.refreshStatusMessage = "Fetched \(localSucceeded) of \(localProcessed) — \(localTotal) total."
+                }
+            } else {
+                let localProcessed = processed
+                let localSucceeded = succeeded
+                let localTotal = queue.count
+                await MainActor.run {
+                    self.negativeCache.insert(entry.hash)
+                    self.refreshProcessed = localProcessed
+                    self.refreshProgress = Double(localProcessed) / Double(localTotal)
+                    self.refreshStatusMessage = "Fetched \(localSucceeded) of \(localProcessed) — \(localTotal) total."
+                }
+            }
+        }
+        let finalSucceeded = succeeded
+        let finalTotal = queue.count
+        let finalProcessed = processed
+        let cancelled = Task.isCancelled
+        await MainActor.run {
+            self.isRefreshing = false
+            self.refreshProgress = 1
+            self.refreshTask = nil
+            if cancelled {
+                self.refreshStatusMessage = "Stopped — fetched \(finalSucceeded) of \(finalProcessed) on \(rootName)."
+            } else {
+                self.refreshStatusMessage = "Done — fetched \(finalSucceeded) of \(finalTotal) on \(rootName)."
+            }
+        }
+    }
+
+    /// Writes the downloaded image to the drive's `HarmonIQ/Artwork/artists/`
+    /// folder (or the local cache for read-only roots), mirrors locally so
+    /// future renders don't hold scope, and bumps `LibraryStore`'s artist
+    /// snapshot so the Artists grid invalidates its representative-image
+    /// cache and re-renders.
+    private func persistDownloadedPhoto(_ data: Data,
+                                        artistHash: String,
+                                        rootBookmarkID: UUID) {
+        guard let root = LibraryStore.shared.roots.first(where: { $0.id == rootBookmarkID }) else { return }
+        let localCache = LibraryStore.shared.artistPhotoDirectory
+
+        let savedFilename: String?
+        if root.isReadOnly {
+            // Read-only roots store all artwork in the sandbox.
+            savedFilename = MetadataExtractor.saveArtwork(data, named: artistHash, to: localCache)
+        } else {
+            do {
+                let driveSaved: String? = try BookmarkStore.withAccess(to: root.bookmark) { driveURL in
+                    let driveArt = DriveLibraryStore.artistArtworkFolder(in: driveURL)
+                    try? FileManager.default.createDirectory(at: driveArt, withIntermediateDirectories: true)
+                    let written = MetadataExtractor.saveArtwork(data, named: artistHash, to: driveArt)
+                    if written != nil {
+                        let src = driveArt.appendingPathComponent("\(artistHash).jpg")
+                        let dst = localCache.appendingPathComponent("\(artistHash).jpg")
+                        if FileManager.default.fileExists(atPath: dst.path) {
+                            try? FileManager.default.removeItem(at: dst)
+                        }
+                        try? FileManager.default.copyItem(at: src, to: dst)
+                    }
+                    return written
+                }
+                savedFilename = driveSaved
+            } catch {
+                savedFilename = nil
+            }
+        }
+
+        guard savedFilename != nil else { return }
+
+        // Bump the artist-photo snapshot so any cached representative-image
+        // pick (which prefers a real photo over an album cover) recomputes.
+        LibraryStore.shared.invalidateArtistRepresentativeCache()
+    }
+
+    // MARK: - Helpers (static / nonisolated)
+
+    nonisolated static func sha1Hex(_ s: String) -> String {
+        let digest = Insecure.SHA1.hash(data: Data(s.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// User-Agent string per MusicBrainz etiquette.
+    nonisolated static func userAgent() -> String {
+        "HarmonIQ/\(BuildInfo.version) (https://github.com/LeoHChen/HarmonIQ)"
+    }
+
+    // MARK: - MusicBrainz → Wikidata → Wikimedia Commons
+
+    /// Per-process cache of MBID → Wikidata image filename ("Foo.jpg") so a
+    /// repeat lookup of the same artist within a session avoids the second
+    /// hop. Negative entries (no MBID, no P18) are tracked via the parent
+    /// `negativeCache` keyed by artist hash.
+    private actor LookupCache {
+        private var mbidToImage: [String: String] = [:]
+        func record(mbid: String, image: String) { mbidToImage[mbid] = image }
+        func image(forMBID mbid: String) -> String? { mbidToImage[mbid] }
+    }
+    nonisolated private static let lookupCache = LookupCache()
+
+    /// Returns image bytes on success, nil on any failure.
+    nonisolated private static func lookupAndDownload(artist: String,
+                                                      rateLimiter: MusicBrainzRateLimiter) async -> Data? {
+        // 1) MusicBrainz artist search — get MBID.
+        await rateLimiter.waitTurn()
+        guard let mbid = await searchArtistMBID(artist: artist) else { return nil }
+
+        // 2) Resolve the Wikidata image filename. Per-process cache so a
+        //    repeat lookup of the same MBID (different runs of the bulk
+        //    pass, or two near-simultaneous fetches from view + Settings)
+        //    skips the round-trip.
+        let imageFilename: String
+        if let cached = await lookupCache.image(forMBID: mbid) {
+            imageFilename = cached
+        } else {
+            await rateLimiter.waitTurn()
+            guard let resolved = await resolveWikidataImage(mbid: mbid) else { return nil }
+            await lookupCache.record(mbid: mbid, image: resolved)
+            imageFilename = resolved
+        }
+
+        // 3) Download the actual image bytes from Wikimedia Commons.
+        return await downloadCommonsImage(filename: imageFilename)
+    }
+
+    /// Searches MusicBrainz for an artist by name and returns the
+    /// highest-scoring MBID. Documented limitation: when MusicBrainz has
+    /// multiple matching artists with the same name we pick the top hit
+    /// without disambiguation.
+    nonisolated private static func searchArtistMBID(artist: String) async -> String? {
+        let escaped = luceneEscape(artist)
+        let query = "artist:\"\(escaped)\""
+        var components = URLComponents(string: "https://musicbrainz.org/ws/2/artist/")
+        components?.queryItems = [
+            URLQueryItem(name: "query", value: query),
+            URLQueryItem(name: "fmt", value: "json"),
+            URLQueryItem(name: "limit", value: "5")
+        ]
+        guard let url = components?.url else { return nil }
+
+        var req = URLRequest(url: url)
+        req.timeoutInterval = 10
+        req.setValue(userAgent(), forHTTPHeaderField: "User-Agent")
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        guard let (data, response) = try? await URLSession.shared.data(for: req) else { return nil }
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            return nil
+        }
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        guard let artists = json["artists"] as? [[String: Any]] else { return nil }
+
+        // Prefer exact name match → high score; otherwise top-scoring entry.
+        let lowered = artist.lowercased()
+        let candidates = artists.compactMap { a -> (id: String, score: Int, nameMatch: Bool)? in
+            guard let id = a["id"] as? String else { return nil }
+            let score = (a["score"] as? Int) ?? 0
+            let name = (a["name"] as? String)?.lowercased() ?? ""
+            return (id, score, name == lowered)
+        }
+        let sorted = candidates.sorted { lhs, rhs in
+            if lhs.nameMatch != rhs.nameMatch { return lhs.nameMatch }
+            return lhs.score > rhs.score
+        }
+        return sorted.first?.id
+    }
+
+    /// Looks up the Wikidata entity ID linked to `mbid` via the MusicBrainz
+    /// `url-rels`, then queries Wikidata for property `P18` (image) on that
+    /// entity. Returns the bare filename (e.g. `"Some Artist.jpg"`).
+    nonisolated private static func resolveWikidataImage(mbid: String) async -> String? {
+        // 3a) MusicBrainz artist with url-rels — look for a Wikidata link.
+        guard let mbURL = URL(string: "https://musicbrainz.org/ws/2/artist/\(mbid)?inc=url-rels&fmt=json") else {
+            return nil
+        }
+        var mbReq = URLRequest(url: mbURL)
+        mbReq.timeoutInterval = 10
+        mbReq.setValue(userAgent(), forHTTPHeaderField: "User-Agent")
+        mbReq.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        guard let (mbData, mbResp) = try? await URLSession.shared.data(for: mbReq) else { return nil }
+        guard let mbHTTP = mbResp as? HTTPURLResponse, (200..<300).contains(mbHTTP.statusCode) else {
+            return nil
+        }
+        guard let mbJSON = try? JSONSerialization.jsonObject(with: mbData) as? [String: Any] else { return nil }
+        let rels = (mbJSON["relations"] as? [[String: Any]]) ?? []
+        var wikidataID: String?
+        for rel in rels {
+            // Both `type` == "wikidata" and a target URL on wikidata.org work.
+            let type = (rel["type"] as? String)?.lowercased() ?? ""
+            let urlObj = rel["url"] as? [String: Any]
+            let resource = (urlObj?["resource"] as? String) ?? ""
+            if type == "wikidata" || resource.contains("wikidata.org/wiki/Q") {
+                if let q = resource.split(separator: "/").last.map(String.init), q.hasPrefix("Q") {
+                    wikidataID = q
+                    break
+                }
+            }
+        }
+        guard let qid = wikidataID else { return nil }
+
+        // 3b) Wikidata: fetch the entity, pull P18.
+        guard let wdURL = URL(string: "https://www.wikidata.org/wiki/Special:EntityData/\(qid).json") else {
+            return nil
+        }
+        var wdReq = URLRequest(url: wdURL)
+        wdReq.timeoutInterval = 10
+        wdReq.setValue(userAgent(), forHTTPHeaderField: "User-Agent")
+        wdReq.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        guard let (wdData, wdResp) = try? await URLSession.shared.data(for: wdReq) else { return nil }
+        guard let wdHTTP = wdResp as? HTTPURLResponse, (200..<300).contains(wdHTTP.statusCode) else {
+            return nil
+        }
+        guard let wdJSON = try? JSONSerialization.jsonObject(with: wdData) as? [String: Any],
+              let entities = wdJSON["entities"] as? [String: Any],
+              let entity = entities[qid] as? [String: Any],
+              let claims = entity["claims"] as? [String: Any],
+              let p18 = claims["P18"] as? [[String: Any]],
+              let firstClaim = p18.first,
+              let mainsnak = firstClaim["mainsnak"] as? [String: Any],
+              let datavalue = mainsnak["datavalue"] as? [String: Any],
+              let value = datavalue["value"] as? String,
+              !value.isEmpty
+        else { return nil }
+        return value
+    }
+
+    /// Wikimedia Commons direct-image URL via the `Special:FilePath`
+    /// redirect (resolves to upload.wikimedia.org). We ask for a 600px
+    /// thumbnail to match what `MetadataExtractor.saveArtwork` re-encodes
+    /// into anyway.
+    nonisolated private static func downloadCommonsImage(filename: String) async -> Data? {
+        // Spaces are converted to underscores by MediaWiki, but Special:FilePath
+        // accepts either form; URLComponents handles the encoding.
+        var components = URLComponents(string: "https://commons.wikimedia.org/wiki/Special:FilePath/")
+        components?.path = "/wiki/Special:FilePath/" + filename
+        components?.queryItems = [URLQueryItem(name: "width", value: "600")]
+        guard let url = components?.url else { return nil }
+
+        var req = URLRequest(url: url)
+        req.timeoutInterval = 15
+        req.setValue(userAgent(), forHTTPHeaderField: "User-Agent")
+        guard let (data, response) = try? await URLSession.shared.data(for: req) else { return nil }
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            return nil
+        }
+        guard !data.isEmpty, UIImage(data: data) != nil else { return nil }
+        return data
+    }
+
+    nonisolated private static func luceneEscape(_ s: String) -> String {
+        let reserved: Set<Character> = ["+", "-", "&", "|", "!", "(", ")", "{", "}", "[", "]", "^", "\"", "~", "*", "?", ":", "\\", "/"]
+        var out = ""
+        out.reserveCapacity(s.count)
+        for ch in s {
+            if reserved.contains(ch) {
+                out.append("\\")
+            }
+            out.append(ch)
+        }
+        return out
+    }
+}

--- a/HarmonIQ/Indexer/ArtworkFetcher.swift
+++ b/HarmonIQ/Indexer/ArtworkFetcher.swift
@@ -67,6 +67,10 @@ final class ArtworkFetcher: ObservableObject {
     /// (small cushion for clock skew).
     private let rateLimiter = MusicBrainzRateLimiter()
 
+    /// Exposed so `ArtistPhotoFetcher` (issue #93) can share the same gate —
+    /// album + artist lookups must not collectively burst past 1 req/sec.
+    var musicBrainzRateLimiter: MusicBrainzRateLimiter { rateLimiter }
+
     private init() {
         self.isOnlineFetchEnabled = UserDefaults.standard.bool(forKey: Self.enabledDefaultsKey)
     }

--- a/HarmonIQ/Persistence/DriveLibraryStore.swift
+++ b/HarmonIQ/Persistence/DriveLibraryStore.swift
@@ -92,6 +92,17 @@ enum DriveLibraryStore {
         harmonIQFolder(in: driveRoot).appendingPathComponent(artworkFolderName, isDirectory: true)
     }
 
+    /// Per-artist photo folder (issue #93). Sibling to `artworkFolder` —
+    /// album covers stay at `<HarmonIQ>/Artwork/<sha1(albumArtist|album)>.jpg`,
+    /// artist photos live one level deeper at
+    /// `<HarmonIQ>/Artwork/artists/<sha1(artistName)>.jpg` so the album
+    /// rescan sweep ignores them.
+    static let artistArtworkFolderName = "artists"
+
+    static func artistArtworkFolder(in driveRoot: URL) -> URL {
+        artworkFolder(in: driveRoot).appendingPathComponent(artistArtworkFolderName, isDirectory: true)
+    }
+
     static func ensureFolders(in driveRoot: URL) throws {
         let fm = FileManager.default
         try fm.createDirectory(at: harmonIQFolder(in: driveRoot), withIntermediateDirectories: true)
@@ -233,6 +244,33 @@ enum DriveLibraryStore {
             try? fm.createDirectory(at: localCache, withIntermediateDirectories: true)
         }
         for src in entries {
+            // Skip subdirectories — `artists/` has its own mirror pass.
+            let isDir = (try? src.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
+            if isDir { continue }
+            let dst = localCache.appendingPathComponent(src.lastPathComponent)
+            if fm.fileExists(atPath: dst.path) {
+                let s = (try? src.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? -1
+                let d = (try? dst.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? -2
+                if s == d { continue }
+                try? fm.removeItem(at: dst)
+            }
+            try? fm.copyItem(at: src, to: dst)
+        }
+    }
+
+    /// Mirrors the drive's per-artist photo folder into the local cache
+    /// (issue #93). Same byte-size shortcut as the album mirror so we don't
+    /// re-copy files that haven't changed across launches.
+    static func mirrorArtistPhotosToLocalCache(driveRoot: URL, localCache: URL) {
+        let driveArt = artistArtworkFolder(in: driveRoot)
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(at: driveArt, includingPropertiesForKeys: [.fileSizeKey], options: [.skipsHiddenFiles]) else { return }
+        if !fm.fileExists(atPath: localCache.path) {
+            try? fm.createDirectory(at: localCache, withIntermediateDirectories: true)
+        }
+        for src in entries {
+            let isDir = (try? src.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
+            if isDir { continue }
             let dst = localCache.appendingPathComponent(src.lastPathComponent)
             if fm.fileExists(atPath: dst.path) {
                 let s = (try? src.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? -1

--- a/HarmonIQ/Persistence/LibraryStore.swift
+++ b/HarmonIQ/Persistence/LibraryStore.swift
@@ -43,6 +43,17 @@ final class LibraryStore: ObservableObject {
         return dir
     }
 
+    /// Local mirror of per-artist photos (issue #93). Sibling to
+    /// `artworkDirectory`; populated by `ArtistPhotoFetcher` and by the
+    /// drive-load mirror pass. Files are named `<sha1(displayArtist)>.jpg`.
+    var artistPhotoDirectory: URL {
+        let dir = artworkDirectory.appendingPathComponent("artists", isDirectory: true)
+        if !FileManager.default.fileExists(atPath: dir.path) {
+            try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        }
+        return dir
+    }
+
     // MARK: - Load / save
 
     func loadFromDisk() async {
@@ -127,6 +138,7 @@ final class LibraryStore: ObservableObject {
         }
 
         let cacheDir = artworkDirectory
+        let artistCacheDir = artistPhotoDirectory
         struct DriveLoad {
             var library: DriveLibraryStore.DriveLibraryFile?
             var playlists: DriveLibraryStore.DrivePlaylistsFile?
@@ -136,6 +148,7 @@ final class LibraryStore: ObservableObject {
             let lib = DriveLibraryStore.loadLibrary(driveRoot: driveURL)
             let pls = DriveLibraryStore.loadPlaylists(driveRoot: driveURL)
             DriveLibraryStore.mirrorArtworkToLocalCache(driveRoot: driveURL, localCache: cacheDir)
+            DriveLibraryStore.mirrorArtistPhotosToLocalCache(driveRoot: driveURL, localCache: artistCacheDir)
             return DriveLoad(library: lib, playlists: pls, currentFingerprint: Self.computeFingerprint(rootURL: driveURL))
         }
         guard let result = result else { return }
@@ -154,6 +167,11 @@ final class LibraryStore: ObservableObject {
         // cheap pass: scan the Artwork folder, match by sha1 filename,
         // patch matching tracks. No-op when everything's already linked.
         reconcileArtworkOnLoad(rootID: root.id)
+
+        // Newly-mirrored artist photos may have appeared in the local
+        // cache during this load — drop the artist-image cache so the
+        // grid re-picks across photo + album cover on the next render.
+        invalidateArtistRepresentativeCache()
 
         // Auto-incremental: if the drive's top-level mtime + child count
         // differ from the last scan, kick off the indexer so newly-added
@@ -669,6 +687,24 @@ final class LibraryStore: ObservableObject {
         tracks.filter { $0.displayArtist == artist }
     }
 
+    /// Picks the drive that should own a downloaded artist photo for
+    /// `artist` (issue #93). Prefers writable drives with the most tracks
+    /// from that artist, ties broken by `roots` order. Returns `nil` when
+    /// the artist isn't on any currently-mounted drive — caller should
+    /// skip the fetch.
+    func preferredDriveForArtist(_ artist: String) -> UUID? {
+        var counts: [UUID: Int] = [:]
+        for t in tracks where t.displayArtist == artist {
+            counts[t.rootBookmarkID, default: 0] += 1
+        }
+        guard !counts.isEmpty else { return nil }
+        // Prefer read-write drives so the photo lands on the drive (and
+        // becomes portable to other devices). Fall back to read-only.
+        let writable = roots.filter { !$0.isReadOnly && counts[$0.id] != nil }
+        let candidates = writable.isEmpty ? roots.filter { counts[$0.id] != nil } : writable
+        return candidates.max { (counts[$0.id] ?? 0) < (counts[$1.id] ?? 0) }?.id
+    }
+
     /// Representative track for an artist (issue #89). Picks the track from
     /// the album the artist has the most tracks on; ties break by album
     /// name (localized standard, ascending). The returned track's
@@ -683,12 +719,50 @@ final class LibraryStore: ObservableObject {
         return artistRepresentativeCache?.map[artist]
     }
 
+    /// What an artist tile should display (issue #93). Returns either a real
+    /// artist photo on disk (preferred) or the representative album cover —
+    /// whichever exists locally. The choice is cached against the same
+    /// snapshot key the representative-track cache uses, plus a manual nonce
+    /// so a freshly-fetched artist photo can invalidate without forcing a
+    /// full library reload.
+    enum ArtistImageSource {
+        /// Path under `artistPhotoDirectory`.
+        case artistPhoto(filename: String)
+        /// Path under `artworkDirectory` (the representative album cover).
+        case albumCover(filename: String)
+    }
+
+    func artistImage(forArtist artist: String) -> ArtistImageSource? {
+        if let cached = artistImageCache,
+           cached.snapshotID == tracksSnapshotID,
+           cached.nonce == artistImageCacheNonce {
+            return cached.map[artist]
+        }
+        rebuildArtistImageCache()
+        return artistImageCache?.map[artist]
+    }
+
+    /// Called by `ArtistPhotoFetcher` after a successful download so the
+    /// artist tile's cached image choice flips from album cover to real
+    /// photo on the next render.
+    func invalidateArtistRepresentativeCache() {
+        artistImageCacheNonce &+= 1
+    }
+
     private struct ArtistRepresentativeCache {
         let snapshotID: Int
         let map: [String: Track]
     }
 
+    private struct ArtistImageCache {
+        let snapshotID: Int
+        let nonce: UInt64
+        let map: [String: ArtistImageSource]
+    }
+
     private var artistRepresentativeCache: ArtistRepresentativeCache?
+    private var artistImageCache: ArtistImageCache?
+    private var artistImageCacheNonce: UInt64 = 0
 
     /// Cheap snapshot identity for the tracks array so the cache can
     /// invalidate when tracks change. Uses count + first/last stableID
@@ -747,6 +821,52 @@ final class LibraryStore: ObservableObject {
             map[artist] = withArt ?? albumTracks.first
         }
         artistRepresentativeCache = ArtistRepresentativeCache(snapshotID: tracksSnapshotID, map: map)
+    }
+
+    /// Computes the per-artist image choice — real artist photo if one
+    /// exists on disk for this artist, otherwise the representative album
+    /// cover (when that track has artwork). Artists with neither don't get
+    /// an entry; the view falls back to the placeholder glyph.
+    private func rebuildArtistImageCache() {
+        if artistRepresentativeCache?.snapshotID != tracksSnapshotID {
+            rebuildArtistRepresentativeCache()
+        }
+        guard let representative = artistRepresentativeCache?.map else {
+            artistImageCache = ArtistImageCache(snapshotID: tracksSnapshotID,
+                                                nonce: artistImageCacheNonce,
+                                                map: [:])
+            return
+        }
+        let fm = FileManager.default
+        let photoDir = artistPhotoDirectory
+        let coverDir = artworkDirectory
+        var map: [String: ArtistImageSource] = [:]
+        map.reserveCapacity(representative.count)
+
+        // Build the artist photo set across every artist we know — even ones
+        // for whom we don't have a representative track (compilation-only
+        // entries, future Various-Artist hits). Cheap one-shot scan.
+        var artistsToCheck: Set<String> = []
+        for artist in representative.keys { artistsToCheck.insert(artist) }
+        for artist in allArtists { artistsToCheck.insert(artist) }
+
+        for artist in artistsToCheck {
+            let photoHash = ArtistPhotoFetcher.sha1Hex(artist)
+            let photoURL = photoDir.appendingPathComponent("\(photoHash).jpg")
+            if fm.fileExists(atPath: photoURL.path) {
+                map[artist] = .artistPhoto(filename: "\(photoHash).jpg")
+                continue
+            }
+            if let track = representative[artist], let cover = track.artworkPath {
+                let coverURL = coverDir.appendingPathComponent(cover)
+                if fm.fileExists(atPath: coverURL.path) {
+                    map[artist] = .albumCover(filename: cover)
+                }
+            }
+        }
+        artistImageCache = ArtistImageCache(snapshotID: tracksSnapshotID,
+                                            nonce: artistImageCacheNonce,
+                                            map: map)
     }
 
     /// Identifier for a single album row in the Albums view. Two flavours:

--- a/HarmonIQ/Views/ArtistsView.swift
+++ b/HarmonIQ/Views/ArtistsView.swift
@@ -1,14 +1,18 @@
 import SwiftUI
 
 /// Artists browse view (issue #89). Visual grid mirroring `AlbumsView` —
-/// each tile shows a representative album cover for the artist (the album
-/// they have the most tracks on, alphabetic tiebreak). Artists with no
-/// artwork get a Winamp-themed placeholder.
+/// each tile shows a real artist photo if one exists locally, otherwise a
+/// representative album cover (PR #92), otherwise a Winamp-themed
+/// placeholder.
 ///
-/// v1 is offline-pure: no network fetches. Network-fetched artist photos
-/// are filed as a follow-up.
+/// Network-fetched artist photos (issue #93) are opt-in via
+/// Settings → Artwork. When the toggle is off, this view never hits the
+/// network. When on, every visible tile fires a single
+/// `ArtistPhotoFetcher.fetchIfMissing` call on appearance — the fetcher's
+/// in-flight + negative cache + 1-req/sec rate limiter handles dedup.
 struct ArtistsView: View {
     @EnvironmentObject var library: LibraryStore
+    @StateObject private var artistPhotoFetcher = ArtistPhotoFetcher.shared
 
     private let columns: [GridItem] = [
         GridItem(.adaptive(minimum: 150), spacing: 16)
@@ -30,6 +34,14 @@ struct ArtistsView: View {
                                 ArtistCard(artist: artist)
                             }
                             .buttonStyle(.plain)
+                            .onAppear {
+                                // Opportunistic fetch — the fetcher gates
+                                // on the toggle, online state, and dedup
+                                // caches, so this is cheap on every cell.
+                                if let drive = library.preferredDriveForArtist(artist) {
+                                    artistPhotoFetcher.fetchIfMissing(artist: artist, rootBookmarkID: drive)
+                                }
+                            }
                         }
                     }
                     .padding(16)
@@ -46,14 +58,14 @@ private struct ArtistCard: View {
     @EnvironmentObject var library: LibraryStore
 
     var body: some View {
-        let representative = library.representativeTrack(forArtist: artist)
+        let imageSource = library.artistImage(forArtist: artist)
         let trackCount = library.tracks(byArtist: artist).count
         VStack(alignment: .leading, spacing: 6) {
             // Use a circular crop for artist tiles to visually distinguish
             // them from album tiles (square). When no artwork at all is
             // attached to the artist's tracks, render the Winamp-themed
             // placeholder glyph.
-            ArtistTile(track: representative, size: 150)
+            ArtistTile(imageSource: imageSource, size: 150)
                 .frame(maxWidth: .infinity)
             Text(artist)
                 .font(.subheadline.weight(.semibold))
@@ -66,12 +78,11 @@ private struct ArtistCard: View {
     }
 }
 
-/// Circular artist tile. Uses the representative track's artwork when one
-/// exists; otherwise renders a microphone glyph in lcdGlow on the panel
-/// gradient — same design language as `ArtworkView`'s placeholder, but
-/// shaped as a circle to read as a "person" rather than an "album."
+/// Circular artist tile. Renders, in order of preference: a real artist
+/// photo (when one exists in the local cache), the representative album
+/// cover, or a microphone glyph placeholder.
 private struct ArtistTile: View {
-    let track: Track?
+    let imageSource: LibraryStore.ArtistImageSource?
     let size: CGFloat
 
     var body: some View {
@@ -100,9 +111,15 @@ private struct ArtistTile: View {
     }
 
     private func loadImage() -> UIImage? {
-        guard let path = track?.artworkPath else { return nil }
-        let url = LibraryStore.shared.artworkDirectory.appendingPathComponent(path)
-        return UIImage(contentsOfFile: url.path)
+        guard let source = imageSource else { return nil }
+        switch source {
+        case .artistPhoto(let filename):
+            let url = LibraryStore.shared.artistPhotoDirectory.appendingPathComponent(filename)
+            return UIImage(contentsOfFile: url.path)
+        case .albumCover(let filename):
+            let url = LibraryStore.shared.artworkDirectory.appendingPathComponent(filename)
+            return UIImage(contentsOfFile: url.path)
+        }
     }
 }
 

--- a/HarmonIQ/Views/SettingsView.swift
+++ b/HarmonIQ/Views/SettingsView.swift
@@ -17,8 +17,10 @@ struct SettingsView: View {
     @EnvironmentObject var library: LibraryStore
     @EnvironmentObject var indexer: MusicIndexer
     @StateObject private var artworkFetcher = ArtworkFetcher.shared
+    @StateObject private var artistPhotoFetcher = ArtistPhotoFetcher.shared
     @State private var showPicker = false
     @State private var bulkConfirmRoot: LibraryRoot?
+    @State private var artistBulkConfirmRoot: LibraryRoot?
     @State private var rebuildConfirmRoot: LibraryRoot?
     @State private var reclassifyStatus: String = ""
 
@@ -90,6 +92,37 @@ struct SettingsView: View {
                     }
                 }
 
+                Toggle(isOn: $artistPhotoFetcher.isOnlineFetchEnabled) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Fetch artist photos online")
+                        Text("Queries MusicBrainz + Wikidata / Wikimedia")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                if artistPhotoFetcher.isOnlineFetchEnabled {
+                    ForEach(library.roots) { root in
+                        Button {
+                            artistBulkConfirmRoot = root
+                        } label: {
+                            Label("Refresh missing artist photos — \(root.displayName)",
+                                  systemImage: "person.crop.circle.badge.plus")
+                        }
+                        .disabled(artistPhotoFetcher.isRefreshing)
+                    }
+                    if artistPhotoFetcher.isRefreshing {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text(artistPhotoFetcher.refreshStatusMessage).font(.caption)
+                            ProgressView(value: artistPhotoFetcher.refreshProgress)
+                            Button("Stop", role: .destructive) { artistPhotoFetcher.cancelRefresh() }
+                        }
+                    } else if !artistPhotoFetcher.refreshStatusMessage.isEmpty {
+                        Text(artistPhotoFetcher.refreshStatusMessage)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
                 ForEach(library.roots) { root in
                     Button {
                         library.rescanArtwork(for: root)
@@ -106,7 +139,7 @@ struct SettingsView: View {
             } header: {
                 Text("Artwork")
             } footer: {
-                Text("Off by default. When on, HarmonIQ sends the album + artist of any track without local art to MusicBrainz to find a cover. Failures are silent — no other data leaves the device.\n\n“Rescan artwork on disk” adopts any covers you dropped into <Drive>/HarmonIQ/Artwork/ matching the sha1(albumArtist|album).jpg naming convention. Files that don't match a known album are ignored.")
+                Text("Both toggles are off by default and independent. When album-art is on, HarmonIQ sends the album + artist of any track without local art to MusicBrainz to find a cover. When artist photos is on, HarmonIQ sends each missing artist's name to MusicBrainz, then to Wikidata, to find a Wikimedia Commons photo. Failures are silent — no other data leaves the device.\n\n“Rescan artwork on disk” adopts any album covers you dropped into <Drive>/HarmonIQ/Artwork/ matching the sha1(albumArtist|album).jpg naming convention. Files that don't match a known album are ignored.")
             }
 
             Section {
@@ -235,6 +268,20 @@ struct SettingsView: View {
             Button("Cancel", role: .cancel) { bulkConfirmRoot = nil }
         } message: {
             Text("This sends one MusicBrainz query per album missing artwork on \(bulkConfirmRoot?.displayName ?? "this drive"), at most 1 request per second. Failures are silent.")
+        }
+        .confirmationDialog("Refresh missing artist photos?",
+                            isPresented: Binding(get: { artistBulkConfirmRoot != nil },
+                                                 set: { if !$0 { artistBulkConfirmRoot = nil } }),
+                            titleVisibility: .visible) {
+            Button("Start refresh") {
+                if let r = artistBulkConfirmRoot {
+                    artistPhotoFetcher.refreshMissingArtistPhotos(for: r)
+                }
+                artistBulkConfirmRoot = nil
+            }
+            Button("Cancel", role: .cancel) { artistBulkConfirmRoot = nil }
+        } message: {
+            Text("This sends each missing artist's name to MusicBrainz then Wikidata to find a Wikimedia Commons photo, at most 1 MusicBrainz request per second on \(artistBulkConfirmRoot?.displayName ?? "this drive"). Failures are silent.")
         }
         .confirmationDialog("Rebuild library from scratch?",
                             isPresented: Binding(get: { rebuildConfirmRoot != nil },


### PR DESCRIPTION
## Summary
- Adds `ArtistPhotoFetcher` — sibling to the existing `ArtworkFetcher`. Looks up an artist's MusicBrainz ID, resolves the Wikidata entity via the MBID's `url-rels`, and downloads the entity's `P18` image from Wikimedia Commons. Off by default; separate Settings toggle from the album-art one so users can opt into one and not the other.
- Shares the existing `MusicBrainzRateLimiter` instance from `ArtworkFetcher.shared`, so album + artist lookups can't burst past 1 req/sec collectively. Reuses the same NWPathMonitor pattern, in-flight + negative caches, and Lucene-escape helper. Wikidata MBID → image-filename results are cached per-process.
- Photos persist on the drive at `<DriveRoot>/HarmonIQ/Artwork/artists/<sha1(artistName)>.jpg` and mirror to the sandbox cache (`Application Support/HarmonIQ/Artwork/artists/`) on download + on drive load. Artists view prefers the real photo over the album-cover fallback from PR #92, with a snapshot+nonce-keyed cache so the grid doesn't churn on scroll.
- Triggers: opportunistic per-tile fetch on `ArtistCard.onAppear` + a per-drive "Refresh missing artist photos" Settings action (with confirmation/progress/Stop) mirroring PR #74 / #79's album-art bulk pass.

## Privacy posture
- Toggle off by default; with the toggle off, no network calls fire from Artists view or the manual refresh action — every public entry point on `ArtistPhotoFetcher` is a no-op.
- Settings copy explicitly says the artist name is sent to MusicBrainz then Wikidata to find a Wikimedia Commons photo. Failures silent.

## Test plan
- [x] Section A (smoke): build cleanly with `DEVELOPER_DIR=… xcodebuild -project HarmonIQ.xcodeproj -scheme HarmonIQ -destination 'platform=iOS Simulator,name=iPhone 17' build`. Launches on iPhone 17, Library tab renders, no crashes in the system log.
- [x] Settings UI: with both toggles off (default), only the existing "Rescan artwork on disk" entries show. Toggling "Fetch artist photos online" on reveals "Refresh missing artist photos — <DriveName>" per drive, distinct icon (`person.crop.circle.badge.plus`).
- [ ] Artists view: with toggle off, no network traffic fires. With toggle on and a connection, opening Artists triggers per-tile `fetchIfMissing` calls; downloaded JPEGs land at `<DriveRoot>/HarmonIQ/Artwork/artists/<sha1>.jpg` and the tile flips from album cover → real photo on next render.
- [ ] Bulk refresh: the per-drive button shows progress + Stop, sends ≥ 1 request per second per artist, persists each result, and reports succeeded/processed/total. Stop halts cleanly.
- [ ] Restart: photos that landed last session are mirrored to the local cache on drive load and continue to display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)