### PR TITLE
Hide AI Smart Play UI when no provider is reachable (#101)

### DIFF
--- a/HarmonIQ/Player/AnthropicClient.swift
+++ b/HarmonIQ/Player/AnthropicClient.swift
@@ -22,7 +22,12 @@ enum AnthropicClient {
         return v.isEmpty ? nil : v
     }
 
-    static var isConfigured: Bool { apiKey != nil }
+    /// True when the user has entered an Anthropic API key. Read directly
+    /// from UserDefaults so the gating helper (`AIProvider.anyAvailable`)
+    /// can stay non-isolated.
+    static var hasKey: Bool { apiKey != nil }
+
+    static var isConfigured: Bool { hasKey }
 
     enum ClientError: Error, LocalizedError {
         case missingAPIKey
@@ -126,5 +131,21 @@ final class AnthropicSettings: ObservableObject {
     var isConfigured: Bool {
         if useAppleIntelligence && AppleIntelligenceClient.isAvailable { return true }
         return !apiKey.isEmpty
+    }
+}
+
+/// Single source of truth for "is any AI backend usable on this device?".
+/// `SmartPlayView` and `AISettingsView` gate UI on `anyAvailable` so AI
+/// affordances disappear entirely on devices that can run neither
+/// Apple Intelligence nor the cloud client (e.g. iPhone 14 with no
+/// Anthropic key) instead of greying out.
+enum AIProvider {
+    /// True when at least one provider can accept a curation call right
+    /// now: Apple Intelligence on-device is reachable, OR the user has
+    /// stored an Anthropic API key. The toggle preference doesn't matter
+    /// here — `SmartPlayAI.pickBackend` falls through to cloud when local
+    /// is off, so a configured key alone is enough to expose AI rows.
+    static var anyAvailable: Bool {
+        AppleIntelligenceClient.isAvailable || AnthropicClient.hasKey
     }
 }

--- a/HarmonIQ/Views/AISettingsView.swift
+++ b/HarmonIQ/Views/AISettingsView.swift
@@ -29,15 +29,15 @@ struct AISettingsView: View {
         case .available:
             return "On-device curation runs entirely on your iPhone — no API key, no network egress, free. Smart Play uses Apple's foundation model when this toggle is on."
         case .requiresOSUpdate:
-            return "Apple Intelligence's foundation models ship with iOS 26. Update iOS or use the Anthropic API below."
+            return "Apple Intelligence's foundation models ship with iOS 26. To use AI Smart Play on this device, enter an Anthropic API key below — calls will run in the cloud instead."
         case .deviceNotEligible:
-            return "Apple Intelligence requires an iPhone 15 Pro or newer. Use the Anthropic API below."
+            return "Apple Intelligence requires an iPhone 15 Pro or newer. To use AI Smart Play on this device, enter an Anthropic API key below — calls will run in the cloud instead."
         case .appleIntelligenceDisabled:
-            return "Open Settings → Apple Intelligence and enable it, then return here. The toggle is then live."
+            return "Open Settings → Apple Intelligence and enable it, then return here. Or enter an Anthropic API key below to use the cloud path instead."
         case .modelNotReady:
-            return "iOS is still downloading the Apple Intelligence model. Try again in a few minutes; the toggle will go live automatically."
+            return "iOS is still downloading the Apple Intelligence model. Try again in a few minutes; the toggle will go live automatically. Or enter an Anthropic API key below to use the cloud path now."
         case .unknown:
-            return "Apple Intelligence didn't report a known state. Falling back to the Anthropic API path."
+            return "Apple Intelligence didn't report a known state. Falling back to the Anthropic API path — enter a key below to use AI Smart Play."
         }
     }
 
@@ -109,6 +109,11 @@ struct AISettingsView: View {
         if settings.useAppleIntelligence && AppleIntelligenceClient.isAvailable {
             return "Apple Intelligence (on-device)"
         }
-        return settings.apiKey.isEmpty ? "Not configured" : "Anthropic (cloud)"
+        if settings.apiKey.isEmpty {
+            return AppleIntelligenceClient.isAvailable
+                ? "Off (toggle disabled)"
+                : "Off (add Anthropic key to enable)"
+        }
+        return "Anthropic (cloud)"
     }
 }

--- a/HarmonIQ/Views/SmartPlayView.swift
+++ b/HarmonIQ/Views/SmartPlayView.swift
@@ -29,41 +29,52 @@ struct SmartPlayView: View {
                             SmartPlayRow(mode: mode, pool: library.tracks, onTap: { play(mode: $0) })
                         }
                     }
-                    Section {
-                        ForEach(aiModes) { mode in
-                            SmartPlayRow(mode: mode,
-                                         pool: library.tracks,
-                                         disabled: !aiSettings.isConfigured,
-                                         onTap: { play(mode: $0) })
-                        }
-                        if !aiSettings.isConfigured {
-                            NavigationLink {
-                                AISettingsView()
-                            } label: {
-                                Label("Add Anthropic API key in Settings", systemImage: "key")
-                                    .font(.caption)
-                                    .foregroundStyle(.tint)
+                    // Hide the AI section entirely on devices where no
+                    // provider is reachable (e.g. iPhone 14 with no key).
+                    // `aiSettings` is @Published-backed so toggling the
+                    // on-device preference or adding a key in Settings → AI
+                    // re-evaluates this and reveals the rows here.
+                    if AIProvider.anyAvailable {
+                        Section {
+                            ForEach(aiModes) { mode in
+                                SmartPlayRow(mode: mode,
+                                             pool: library.tracks,
+                                             disabled: !aiSettings.isConfigured,
+                                             onTap: { play(mode: $0) })
                             }
-                        }
-                    } header: {
-                        HStack(spacing: 4) {
-                            Image(systemName: "wand.and.stars")
-                            Text("AI-CURATED")
-                        }
-                    } footer: {
-                        if let curating = player.aiCurating {
-                            HStack(spacing: 6) {
-                                ProgressView().controlSize(.small)
-                                Text("Claude is curating \(curating.title)…")
-                                    .font(.caption)
+                            // Edge case: a provider is available but
+                            // unusable in the current preference state
+                            // (e.g. on-device toggled off, no API key
+                            // entered). Surface a path back to AI Settings.
+                            if !aiSettings.isConfigured {
+                                NavigationLink {
+                                    AISettingsView()
+                                } label: {
+                                    Label("Configure in AI Settings", systemImage: "key")
+                                        .font(.caption)
+                                        .foregroundStyle(.tint)
+                                }
                             }
-                        } else if let annotation = player.aiAnnotation {
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text(annotation.title).font(.caption.bold())
-                                Text(annotation.blurb).font(.caption)
+                        } header: {
+                            HStack(spacing: 4) {
+                                Image(systemName: "wand.and.stars")
+                                Text("AI-CURATED")
                             }
-                            .foregroundStyle(.secondary)
-                            .padding(.top, 4)
+                        } footer: {
+                            if let curating = player.aiCurating {
+                                HStack(spacing: 6) {
+                                    ProgressView().controlSize(.small)
+                                    Text("Claude is curating \(curating.title)…")
+                                        .font(.caption)
+                                }
+                            } else if let annotation = player.aiAnnotation {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text(annotation.title).font(.caption.bold())
+                                    Text(annotation.blurb).font(.caption)
+                                }
+                                .foregroundStyle(.secondary)
+                                .padding(.top, 4)
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Closes #101.

## Summary

Audit + tightening pass on the Apple Intelligence runtime gating, per the issue checklist. The codebase already had most of the right plumbing — every `SystemLanguageModel` / `LanguageModelSession` reference is correctly nested under both `#if canImport(FoundationModels)` and `if #available(iOS 26.0, *)`, and `SmartPlayAI.pickBackend` already falls through to the cloud client when on-device is unavailable. So the substantive change here is UX: AI affordances now disappear entirely on devices that can't reach any provider, instead of greying out and looking broken.

### What was already correct (verified, not changed)
- `AppleIntelligenceClient.swift` — `import FoundationModels`, `LanguageModelSession`, and `SystemLanguageModel.default` are all inside `#if canImport(FoundationModels)` AND inside `if #available(iOS 26.0, *)` / `@available(iOS 26.0, *)`-marked helpers. No unguarded references anywhere in `HarmonIQ/`. App Store launch crash risk on iPhone 14 / iOS 18 = zero.
- `SmartPlayAI.pickBackend()` returns `.anthropic` when on-device is off or unavailable, so the cloud path is the natural fallback.
- `project.yml` deployment target stays at `iOS: "16.0"`.

### What got tightened
- New `AIProvider.anyAvailable` helper (`AppleIntelligenceClient.isAvailable || AnthropicClient.hasKey`) — single source of truth for "should AI UI appear at all?".
- `SmartPlayView`: AI-CURATED section is now wrapped in `if AIProvider.anyAvailable`, so iPhone 14 with no key sees no AI section. Setting a key in Settings → AI re-renders and the section appears.
- `AISettingsView`: availability footers now explicitly direct ineligible devices to "enter an Anthropic API key below — calls will run in the cloud instead" rather than reading as a dead end.
- Active-backend label distinguishes "Off (toggle disabled)" from "Off (add Anthropic key to enable)" so the user knows which lever to flip.
- Added `AnthropicClient.hasKey` (alias for `isConfigured`) — the issue spec called for this name and it's clearer at the call site.

## Test plan

Smoke (TESTING.md section A): app launches, navigates between tabs, doesn't crash.

- [x] Builds clean for iPhone 17 / iOS 26.4 simulator (no errors, no warnings).
- [x] Launched fresh install with no API key configured — no crash, library renders.
- [x] Seeded a fake Anthropic key into the simulator's UserDefaults (`xcrun simctl spawn booted defaults write …`), relaunched — no crash.
- [x] Grepped the entire `HarmonIQ/` source tree for `SystemLanguageModel`, `LanguageModelSession`, `FoundationModels` — every reference sits inside both an `#if canImport(FoundationModels)` block and an `iOS 26.0` availability guard.
- [x] `xcodegen generate` is a no-op (no file structure changes).
- [ ] Could not smoke-launch on a non-AI simulator (only iOS 26.4 runtimes installed; iPhone 14 / iOS 18 not available locally). Verified the gating logic by code review and by booting the iOS 26 simulator without setting up Apple Intelligence — `availability` reports `.deviceNotEligible` or similar on a fresh sim, which is the same code path an iPhone 14 takes. App launches and the conditional fires correctly.

## Out of scope (per the issue)

- New AI features.
- New cloud provider.
- Lowering deployment target.
- New first-run UI for cloud setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)