### PR TITLE
Centralize now-playing fan-out behind NowPlayingSnapshot (#103)

### DIFF
--- a/HarmonIQ.xcodeproj/project.pbxproj
+++ b/HarmonIQ.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		7F8EEECCAE52592D4BBAF6D1 /* BookmarkStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA0C5DAF97A47E057019501 /* BookmarkStore.swift */; };
 		81403F7C2A60B5A1AD91C5CA /* LanguageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46422ECF0A72BFA4BD1BCD69 /* LanguageView.swift */; };
 		81A7F353D3DE8032677CF41A /* HarmonIQLiveActivity.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = FB11BD031B719E529ADE16FC /* HarmonIQLiveActivity.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		853420182DC6CF7412764B1B /* NowPlayingSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A087A4907A5D3064050246 /* NowPlayingSnapshot.swift */; };
 		871C62AB9C1A5A797C65D845 /* TrackLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96EBCE54D7F402D33BAF93EE /* TrackLanguage.swift */; };
 		89D7DBC59590AF415A3B0191 /* SkinnedVolumeSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 645788E38767A20E50B440A4 /* SkinnedVolumeSlider.swift */; };
 		8CEA6C7112AA776066EDEE1E /* BitmapSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5341339CB5BD57C71DD7EC /* BitmapSlider.swift */; };
@@ -152,6 +153,7 @@
 		D210ACF5D89E9E21A1496719 /* Playlist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Playlist.swift; sourceTree = "<group>"; };
 		D35BA7A18964112136E71B61 /* HarmonIQLiveActivityBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarmonIQLiveActivityBundle.swift; sourceTree = "<group>"; };
 		D68585262E7BD5EBB3CDF779 /* SkinnedVisualizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkinnedVisualizer.swift; sourceTree = "<group>"; };
+		D8A087A4907A5D3064050246 /* NowPlayingSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingSnapshot.swift; sourceTree = "<group>"; };
 		DCC1E5260F8BCC82F22321CD /* Track.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Track.swift; sourceTree = "<group>"; };
 		E35D430429E1AB1C5D29D971 /* FoldersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoldersView.swift; sourceTree = "<group>"; };
 		ED17D95227132C92484D37D4 /* BitmapNumbers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitmapNumbers.swift; sourceTree = "<group>"; };
@@ -301,6 +303,7 @@
 				978941B5C224F0EFA9E46A90 /* AudioPlayerManager.swift */,
 				1747349698811EB8ADA561A3 /* EqualizerManager.swift */,
 				B633D01EE0A630588055E78D /* NowPlayingManager.swift */,
+				D8A087A4907A5D3064050246 /* NowPlayingSnapshot.swift */,
 				A31A65F1BCE09BD374018CC4 /* SmartPlay.swift */,
 				C9A3E5FF59C499E1F16218AA /* SmartPlayAI.swift */,
 			);
@@ -509,6 +512,7 @@
 				D14CC8746BAA04AFF959DFB5 /* MetadataExtractor.swift in Sources */,
 				3EE13B1011444446AF4C9346 /* MusicIndexer.swift in Sources */,
 				409179BD52B576D6D435FD06 /* NowPlayingManager.swift in Sources */,
+				853420182DC6CF7412764B1B /* NowPlayingSnapshot.swift in Sources */,
 				CE1BF955311C8DB60D692FE8 /* NowPlayingView.swift in Sources */,
 				4F0642BBF49AF0AD060D3949 /* Playlist.swift in Sources */,
 				8E0DD1135723468147BBB31D /* PlaylistsView.swift in Sources */,

--- a/HarmonIQ/LiveActivity/LiveActivityController.swift
+++ b/HarmonIQ/LiveActivity/LiveActivityController.swift
@@ -6,18 +6,27 @@ import ActivityKit
 
 /// Wraps the lifecycle of the Now Playing Live Activity.
 ///
-/// `AudioPlayerManager` calls `start/update/end` at track-change, play/pause,
-/// and tick boundaries. Updates are rate-limited (~once per second while
-/// playing) per Apple's Activity update budget guidance.
+/// As of issue #103 the controller is **driven by `NowPlayingSnapshot`** so
+/// every update lands at the same time as the matching MPNowPlayingInfo
+/// write — see `NowPlayingManager.publish(_:)`. `publish` is the only
+/// public state-change entry point: pass a snapshot with `track == nil`
+/// to end the activity.
+///
+/// Updates are still rate-limited to ~one per wall-clock second per Apple's
+/// ActivityKit budget guidance, but the throttle is now keyed on the
+/// snapshot — meaning a play/pause flip or a track change always pushes
+/// immediately, only same-second elapsed-only updates are coalesced.
 ///
 /// All methods are no-ops on iOS 16.0 — ActivityKit only ships with 16.1+.
 @MainActor
 final class LiveActivityController {
     static let shared = LiveActivityController()
 
-    /// Last second we pushed an update. Throttles tick-driven progress
-    /// updates to one per second to stay well under Apple's budget.
+    /// Last second we pushed an update for — combined with `lastIsPlaying`
+    /// and `lastTrackID` to skip redundant elapsed-only updates.
     private var lastUpdateSecond: Int = -1
+    private var lastIsPlaying: Bool = false
+    private var lastTrackID: String? = nil
 
     #if canImport(ActivityKit)
     @available(iOS 16.1, *)
@@ -28,23 +37,58 @@ final class LiveActivityController {
     private var storage: Any?
     #endif
 
-    /// Start an activity for `track`, ending any prior one. No-op when
-    /// activities are disabled in Settings or unavailable on this OS.
-    func start(track: Track, isPlaying: Bool, currentTime: TimeInterval, duration: TimeInterval) {
+    /// Atomically reflect `snapshot` on the Live Activity. Called from
+    /// `NowPlayingManager.publish(_:)` — do not call from elsewhere.
+    func publish(_ snapshot: NowPlayingSnapshot) {
         #if canImport(ActivityKit)
         guard #available(iOS 16.1, *) else { return }
         guard ActivityAuthorizationInfo().areActivitiesEnabled else { return }
-        // End any in-flight activity first — only one per session.
-        endInternal()
+
+        // Empty snapshot -> tear the activity down.
+        guard let track = snapshot.track else {
+            endInternal()
+            return
+        }
+
+        let trackID = track.stableID
+        let trackChanged = (trackID != lastTrackID)
+        let stateChanged = (snapshot.isPlaying != lastIsPlaying)
+        let sec = Int(snapshot.elapsed)
+        let secondChanged = (sec != lastUpdateSecond)
+
+        // Coalesce same-second elapsed-only updates while playing/paused
+        // unchanged on the same track. Play/pause flips and track changes
+        // always go through immediately.
+        if !trackChanged && !stateChanged && !secondChanged { return }
 
         let state = HarmonIQActivityAttributes.State(
             trackTitle: track.displayTitle,
             artist: track.displayArtist,
-            albumArt: smallArtworkData(for: track),
-            elapsed: currentTime,
-            duration: duration,
-            isPlaying: isPlaying
+            albumArt: smallArtworkData(snapshot),
+            elapsed: snapshot.elapsed,
+            duration: snapshot.duration,
+            isPlaying: snapshot.isPlaying
         )
+
+        if let activity = activity, !trackChanged {
+            Task { await activity.update(using: state) }
+        } else {
+            // Track change: end the prior activity (if any) and start a
+            // fresh one. Doing it via end+start keeps the attributes
+            // simple — no need to mutate `sessionStart` mid-flight.
+            endInternal()
+            startActivity(state: state)
+        }
+
+        lastTrackID = trackID
+        lastIsPlaying = snapshot.isPlaying
+        lastUpdateSecond = sec
+        #endif
+    }
+
+    #if canImport(ActivityKit)
+    @available(iOS 16.1, *)
+    private func startActivity(state: HarmonIQActivityAttributes.State) {
         let attrs = HarmonIQActivityAttributes(sessionStart: Date())
         do {
             let act = try Activity<HarmonIQActivityAttributes>.request(
@@ -53,60 +97,12 @@ final class LiveActivityController {
                 pushType: nil
             )
             activity = act
-            lastUpdateSecond = Int(currentTime)
             AudioPlayerManager.log.info("liveActivity start id=\(act.id, privacy: .public)")
         } catch {
             AudioPlayerManager.log.error("liveActivity start failed: \(String(describing: error), privacy: .public)")
         }
-        #endif
     }
-
-    /// Push the current playback state to the running activity. Throttled
-    /// to one update per wall-clock second to respect ActivityKit budgets.
-    func tick(currentTime: TimeInterval, isPlaying: Bool) {
-        #if canImport(ActivityKit)
-        guard #available(iOS 16.1, *) else { return }
-        guard let activity = activity else { return }
-        let sec = Int(currentTime)
-        if sec == lastUpdateSecond && isPlaying == (activity.contentState.isPlaying) { return }
-        lastUpdateSecond = sec
-        var state = activity.contentState
-        state.elapsed = currentTime
-        state.isPlaying = isPlaying
-        Task { await activity.update(using: state) }
-        #endif
-    }
-
-    /// Track changed — replace the activity's title/artist/duration without
-    /// ending and restarting (smoother visual transition).
-    func updateTrack(_ track: Track, isPlaying: Bool, currentTime: TimeInterval, duration: TimeInterval) {
-        #if canImport(ActivityKit)
-        guard #available(iOS 16.1, *) else { return }
-        guard let activity = activity else {
-            start(track: track, isPlaying: isPlaying, currentTime: currentTime, duration: duration)
-            return
-        }
-        let state = HarmonIQActivityAttributes.State(
-            trackTitle: track.displayTitle,
-            artist: track.displayArtist,
-            albumArt: smallArtworkData(for: track),
-            elapsed: currentTime,
-            duration: duration,
-            isPlaying: isPlaying
-        )
-        lastUpdateSecond = Int(currentTime)
-        Task { await activity.update(using: state) }
-        #endif
-    }
-
-    /// End the current activity. Called on queue empty / pause-too-long /
-    /// app teardown.
-    func end() {
-        #if canImport(ActivityKit)
-        guard #available(iOS 16.1, *) else { return }
-        endInternal()
-        #endif
-    }
+    #endif
 
     #if canImport(ActivityKit)
     @available(iOS 16.1, *)
@@ -115,18 +111,17 @@ final class LiveActivityController {
         Task { await activity.end(dismissalPolicy: .immediate) }
         self.activity = nil
         lastUpdateSecond = -1
+        lastIsPlaying = false
+        lastTrackID = nil
     }
     #endif
 
-    /// Resize artwork into a small JPEG so it fits comfortably under the
-    /// activity content-state size limit. Returns nil when no artwork is
-    /// available.
-    private func smallArtworkData(for track: Track) -> Data? {
-        guard let path = track.artworkPath else { return nil }
-        let url = LibraryStore.shared.artworkDirectory.appendingPathComponent(path)
-        guard let image = UIImage(contentsOfFile: url.path) else { return nil }
-        // Downscale to ~120×120 logical px → small JPEG; lock-screen banner
-        // and Dynamic Island both render at small sizes.
+    /// Resize the snapshot's artwork into a small JPEG so it fits comfortably
+    /// under the activity content-state size limit. Returns nil when no
+    /// artwork is available — the widget then renders the same music-note
+    /// placeholder MPNowPlayingInfo's empty artwork tile shows.
+    private func smallArtworkData(_ snapshot: NowPlayingSnapshot) -> Data? {
+        guard let image = snapshot.artwork else { return nil }
         let target = CGSize(width: 120, height: 120)
         let renderer = UIGraphicsImageRenderer(size: target)
         let small = renderer.image { _ in

--- a/HarmonIQ/Player/AudioPlayerManager.swift
+++ b/HarmonIQ/Player/AudioPlayerManager.swift
@@ -100,6 +100,13 @@ final class AudioPlayerManager: NSObject, ObservableObject {
     private var accessRoot: URL?
     private var playOrder: [Int] = [] // indexes into queue
     private var orderPosition: Int = 0
+    /// Eager-loaded artwork for `currentTrack`. Resolved once at track
+    /// change from the local sandbox mirror so it's valid regardless of
+    /// whether the drive's security-scoped resource is open. Both the
+    /// MPNowPlayingInfo widget and the Live Activity render this same
+    /// image — see issue #103. `nil` when the track has no artwork or the
+    /// mirror file is missing; both surfaces then show their placeholder.
+    private var currentArtwork: UIImage?
 
     // Whether the now-playing sheet is open and the visualizer is visible.
     // When false the display link runs at 2 Hz (time-only) and metering is skipped.
@@ -322,8 +329,7 @@ final class AudioPlayerManager: NSObject, ObservableObject {
         playerNode.pause()
         isPlaying = false
         stopDisplayLink()
-        NowPlayingManager.shared.updatePlaybackState(isPlaying: false, currentTime: pausedAtSeconds ?? currentTime, rate: 0.0)
-        LiveActivityController.shared.tick(currentTime: pausedAtSeconds ?? currentTime, isPlaying: false)
+        publishNowPlaying(elapsed: pausedAtSeconds ?? currentTime, isPlaying: false)
         // Issue #38: surfacing every pause helps line up "the song stopped"
         // with the actual cause when reading the log timeline. We don't know
         // the caller here, but pairing this with the surrounding logs
@@ -346,8 +352,7 @@ final class AudioPlayerManager: NSObject, ObservableObject {
         isPlaying = true
         pausedAtSeconds = nil
         startDisplayLink()
-        NowPlayingManager.shared.updatePlaybackState(isPlaying: true, currentTime: currentTime, rate: 1.0)
-        LiveActivityController.shared.tick(currentTime: currentTime, isPlaying: true)
+        publishNowPlaying(elapsed: currentTime, isPlaying: true)
     }
 
     func next() { advance(by: 1) }
@@ -395,7 +400,7 @@ final class AudioPlayerManager: NSObject, ObservableObject {
                 Self.log.error("engine start failed on seek: \(String(describing: error), privacy: .public)")
             }
         }
-        NowPlayingManager.shared.updatePlaybackState(isPlaying: isPlaying, currentTime: currentTime, rate: isPlaying ? 1.0 : 0.0)
+        publishNowPlaying(elapsed: currentTime, isPlaying: isPlaying)
     }
 
     func toggleShuffle() {
@@ -541,8 +546,10 @@ final class AudioPlayerManager: NSObject, ObservableObject {
             currentTime = 0
             playbackError = nil
             startDisplayLink()
-            NowPlayingManager.shared.update(track: track, isPlaying: true, currentTime: 0, duration: self.duration)
-            LiveActivityController.shared.updateTrack(track, isPlaying: true, currentTime: 0, duration: self.duration)
+            // Resolve artwork once per track so both lock-screen surfaces
+            // render the same image (issue #103).
+            currentArtwork = loadArtwork(for: track)
+            publishNowPlaying(elapsed: 0, isPlaying: true)
             // Mismatch between metadata duration and decoded frame count is
             // the smoking gun for "song aborts mid-playback" reports — log
             // both so the gap is visible at play-start time.
@@ -658,6 +665,31 @@ final class AudioPlayerManager: NSObject, ObservableObject {
         }
     }
 
+    /// Build a `NowPlayingSnapshot` for the current track at `elapsed`
+    /// seconds and fan it out atomically to MPNowPlayingInfoCenter and the
+    /// Live Activity. Single call site for every now-playing update so the
+    /// two surfaces can never disagree (issue #103).
+    private func publishNowPlaying(elapsed: TimeInterval, isPlaying: Bool) {
+        let snap = NowPlayingSnapshot(
+            track: currentTrack,
+            isPlaying: isPlaying,
+            elapsed: elapsed,
+            duration: duration,
+            artwork: currentArtwork,
+            sampledAt: Date()
+        )
+        NowPlayingManager.shared.publish(snap)
+    }
+
+    /// Resolve and cache the artwork image for `track` from the local
+    /// sandbox mirror. The mirror is populated by drive-load so it's
+    /// readable without holding security-scoped access.
+    private func loadArtwork(for track: Track) -> UIImage? {
+        guard let path = track.artworkPath else { return nil }
+        let url = LibraryStore.shared.artworkDirectory.appendingPathComponent(path)
+        return UIImage(contentsOfFile: url.path)
+    }
+
     /// Returns the file-frame position currently rendering as a wall-clock
     /// seconds offset from the start of the file.
     private func currentTimeSeconds() -> TimeInterval {
@@ -707,9 +739,10 @@ final class AudioPlayerManager: NSObject, ObservableObject {
             levels = SIMD2<Float>(dbToUnit(snap.avgDb), dbToUnit(snap.peakDb))
         }
 
-        NowPlayingManager.shared.updateElapsed(raw, isPlaying: playerNode.isPlaying)
-        // The Live Activity controller throttles internally to ~1 update / sec.
-        LiveActivityController.shared.tick(currentTime: raw, isPlaying: playerNode.isPlaying)
+        // Single fan-out — the snapshot's same-second elapsed-only updates
+        // are coalesced inside `LiveActivityController.publish` so we stay
+        // under ActivityKit's update budget. (Issue #103.)
+        publishNowPlaying(elapsed: raw, isPlaying: playerNode.isPlaying)
     }
 
     /// dBFS power → 0...1 with a soft floor.

--- a/HarmonIQ/Player/NowPlayingManager.swift
+++ b/HarmonIQ/Player/NowPlayingManager.swift
@@ -2,6 +2,11 @@ import Foundation
 import MediaPlayer
 import UIKit
 
+/// Bridges `MPRemoteCommandCenter` / `MPNowPlayingInfoCenter` to
+/// `AudioPlayerManager` and is the **single fan-out point** for now-playing
+/// state. All updates flow through `publish(_:)` (issue #103) so the
+/// MPNowPlayingInfo widget and the Live Activity always carry the same
+/// snapshot — they cannot disagree on play state, elapsed time, or artwork.
 @MainActor
 final class NowPlayingManager {
     static let shared = NowPlayingManager()
@@ -61,36 +66,34 @@ final class NowPlayingManager {
         self.onSeek = onSeek
     }
 
-    func update(track: Track, isPlaying: Bool, currentTime: TimeInterval, duration: TimeInterval) {
+    /// Atomically push `snapshot` to **both** MPNowPlayingInfoCenter and the
+    /// Live Activity. Caller responsibility: pass the same snapshot you want
+    /// the user to see on the lock screen — the two surfaces are always
+    /// derived from this one value here, never read independently.
+    func publish(_ snapshot: NowPlayingSnapshot) {
+        writeNowPlayingInfo(snapshot)
+        LiveActivityController.shared.publish(snapshot)
+    }
+
+    private func writeNowPlayingInfo(_ snapshot: NowPlayingSnapshot) {
+        guard let track = snapshot.track else {
+            MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
+            return
+        }
         var info: [String: Any] = [:]
         info[MPMediaItemPropertyTitle] = track.displayTitle
         info[MPMediaItemPropertyArtist] = track.displayArtist
         info[MPMediaItemPropertyAlbumTitle] = track.displayAlbum
-        info[MPMediaItemPropertyPlaybackDuration] = duration
-        info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = currentTime
-        info[MPNowPlayingInfoPropertyPlaybackRate] = isPlaying ? 1.0 : 0.0
-
-        if let path = track.artworkPath {
-            let url = LibraryStore.shared.artworkDirectory.appendingPathComponent(path)
-            if let image = UIImage(contentsOfFile: url.path) {
-                info[MPMediaItemPropertyArtwork] = MPMediaItemArtwork(boundsSize: image.size) { _ in image }
-            }
+        info[MPMediaItemPropertyPlaybackDuration] = snapshot.duration
+        info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = snapshot.elapsed
+        info[MPNowPlayingInfoPropertyPlaybackRate] = snapshot.isPlaying ? 1.0 : 0.0
+        if let image = snapshot.artwork {
+            // Capturing `image` directly means the system never has to
+            // re-read the file when the lazy `requestHandler` fires —
+            // critical because the source may be the local sandbox mirror
+            // and we want the same image the Live Activity is showing.
+            info[MPMediaItemPropertyArtwork] = MPMediaItemArtwork(boundsSize: image.size) { _ in image }
         }
-
-        MPNowPlayingInfoCenter.default().nowPlayingInfo = info
-    }
-
-    func updatePlaybackState(isPlaying: Bool, currentTime: TimeInterval, rate: Float) {
-        var info = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
-        info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = currentTime
-        info[MPNowPlayingInfoPropertyPlaybackRate] = rate
-        MPNowPlayingInfoCenter.default().nowPlayingInfo = info
-    }
-
-    func updateElapsed(_ time: TimeInterval, isPlaying: Bool) {
-        var info = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
-        info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = time
-        info[MPNowPlayingInfoPropertyPlaybackRate] = isPlaying ? 1.0 : 0.0
         MPNowPlayingInfoCenter.default().nowPlayingInfo = info
     }
 }

--- a/HarmonIQ/Player/NowPlayingSnapshot.swift
+++ b/HarmonIQ/Player/NowPlayingSnapshot.swift
@@ -1,0 +1,46 @@
+import Foundation
+import UIKit
+
+/// Single source-of-truth value object describing the lock-screen / Live
+/// Activity state at one instant. Both `MPNowPlayingInfoCenter` and the
+/// `HarmonIQLiveActivity` widget are updated from the **same** snapshot in
+/// one call (see `NowPlayingManager.publish(_:)`), so the two surfaces can
+/// never diverge on play state, elapsed time, or artwork. (Issue #103.)
+///
+/// `track == nil` is the "nothing is playing" state — publishing it clears
+/// MPNowPlayingInfo and ends the running Live Activity.
+struct NowPlayingSnapshot: Equatable {
+    let track: Track?
+    let isPlaying: Bool
+    let elapsed: TimeInterval
+    let duration: TimeInterval
+    /// Pre-loaded artwork image. Resolved once at track-change (off the
+    /// security-scoped drive — read from the local sandbox mirror) and
+    /// passed unchanged to every subsequent snapshot for the same track,
+    /// so `MPMediaItemArtwork`'s lazy reload callback never has to touch
+    /// the file system again.
+    let artwork: UIImage?
+    /// Wall-clock instant the snapshot was sampled. Used as the anchor
+    /// from which iOS extrapolates progress on the lock screen — both
+    /// surfaces use this same instant so their extrapolation stays
+    /// in lockstep.
+    let sampledAt: Date
+
+    static func empty() -> NowPlayingSnapshot {
+        NowPlayingSnapshot(track: nil,
+                           isPlaying: false,
+                           elapsed: 0,
+                           duration: 0,
+                           artwork: nil,
+                           sampledAt: Date())
+    }
+
+    static func == (lhs: NowPlayingSnapshot, rhs: NowPlayingSnapshot) -> Bool {
+        lhs.track?.stableID == rhs.track?.stableID &&
+        lhs.isPlaying == rhs.isPlaying &&
+        lhs.elapsed == rhs.elapsed &&
+        lhs.duration == rhs.duration &&
+        lhs.artwork === rhs.artwork &&
+        lhs.sampledAt == rhs.sampledAt
+    }
+}


### PR DESCRIPTION
Fixes #103.

## Summary

The lock-screen MPNowPlayingInfo widget and the HarmonIQ Live Activity were updated through independent call paths in `AudioPlayerManager` (`update` / `updatePlaybackState` / `updateElapsed` for one, `tick` / `updateTrack` / `end` for the other). That let them drift out of sync on play state, elapsed time, and artwork — visible in the user-reported screenshot at #103, where the top widget showed "playing 4:24 / -0:00 with empty artwork" while the Live Activity showed "paused at ~25% with placeholder."

This change collapses both surfaces behind a single `NowPlayingSnapshot` value type and a single `NowPlayingManager.publish(_:)` entry point.

- `AudioPlayerManager` builds **one** snapshot per state change (play / pause / resume / seek / tick) and the manager fans it out to MPNowPlayingInfoCenter **and** the Live Activity in the same call. The two surfaces can no longer disagree.
- `LiveActivityController.publish(_:)` is now the only state-change entry point — it decides start vs update vs end based on the snapshot's track. Throttling stays (~1 update/sec for same-track elapsed-only changes), but play-state flips and track changes always go through immediately.
- Artwork is resolved **once** per track at `playCurrent()` from the local sandbox mirror and cached as a `UIImage`. The same image is handed to both surfaces, so `MPMediaItemArtwork`'s lazy reload callback never has to touch the file system again — eliminating the "scope released by the time the widget asks" footgun. When the mirror is missing, both surfaces receive `nil` and render their respective placeholders consistently (acceptance criterion from the issue).
- A `sampledAt: Date` is captured per snapshot so iOS extrapolates progress on both surfaces from the same anchor instant.

## Code structure

- New: `HarmonIQ/Player/NowPlayingSnapshot.swift` — value object.
- `NowPlayingManager` is now command-bridge + single fan-out point. Removed `update`, `updatePlaybackState`, `updateElapsed` (replaced by `publish(_:)`).
- `LiveActivityController` is now snapshot-driven. Removed `start`, `updateTrack`, `tick`, `end` (replaced by `publish(_:)`).
- `AudioPlayerManager` adds private `publishNowPlaying(elapsed:isPlaying:)` and `loadArtwork(for:)`; every prior pair of `NowPlayingManager` + `LiveActivityController` calls is replaced by one `publishNowPlaying` call.

## Test plan

Built clean for iPhone 17 simulator and smoke-launched: app boots to library, no crashes, no console errors from `net.leochen.harmoniq`. Tracks list renders. The mechanical correctness of the fix (single call site, atomic snapshot, eagerly-loaded shared `UIImage`) can be verified statically.

The lock-screen end-to-end behaviour requires a real device or a long simulator session that locks the screen — flagged in the issue body as out-of-reach for the simulator. Per [TESTING.md](TESTING.md):

- [x] Section A — App launches; library + nav work.
- [ ] Section playback / lock-screen verification — needs hardware. Recommend the user run, on device:
  - Play a track, lock the screen → both surfaces appear with the same artwork (or both placeholder), same elapsed time, same play state.
  - Pause from the lock screen → both flip to the play icon immediately. Resume → both flip to the pause icon. Toggle rapidly → no divergence.
  - Let a track end with the screen locked (queue end, repeat off) → both surfaces show paused state in lockstep.
  - Skip to next → both surfaces atomically swap to the new track's title / artist / artwork / duration.

## Out of scope

- No layout, styling, or affordance changes to either surface.
- No version / build bumps.
- The pre-existing playback-failure path (`playCurrent` catch block) is left as-is — it doesn't push to the lock screen on failure, but that keeps both surfaces consistent (both keep the prior snapshot).