### PR TITLE
Bump to 1.1 (build 5); v1.1 release notes in README + landing site

### DIFF
--- a/HarmonIQ/Info.plist
+++ b/HarmonIQ/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.1</string>
 	<key>CFBundleVersion</key>
-	<string>4</string>
+	<string>5</string>
 	<key>LSSupportsOpeningDocumentsInPlace</key>
 	<true/>
 	<key>NSAppleMusicUsageDescription</key>

--- a/HarmonIQLiveActivity/Info.plist
+++ b/HarmonIQLiveActivity/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.1</string>
 	<key>CFBundleVersion</key>
-	<string>4</string>
+	<string>5</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/README.md
+++ b/README.md
@@ -95,6 +95,26 @@ project.yml                  # XcodeGen source
 
 See [GitHub Releases](https://github.com/LeoHChen/HarmonIQ/releases) for the full notes and tag history.
 
+### v1.1 — 2026-05-03
+
+The "make it look right, find it fast, keep it offline" release. Polish across the palette, the browse modes, the maintenance flows, and the lock-screen — without giving up the offline-first stance.
+
+**Charcoal Phosphor.** A more authentically Winamp-2.x palette: graphite chassis, deeper CRT-green LCD, sharper corners, amber + red chromatic accents in the spectrum visualizer. The whole player feels heavier and more "machined" without changing a single feature. (#76)
+
+**Browse by language.** New Library → **Language** hub partitions the library into Chinese / English / Others using a heuristic CJK + Latin classifier. Useful when your collection sprawls across scripts. (#91)
+
+**Artists, with photos.** New Artists browse renders as a visual grid with representative covers, then upgrades to *real* artist headshots when the opt-in network photo fetcher is enabled (MusicBrainz → Wikidata → Wikimedia → TheAudioDB → Wikipedia). Artist tiles are guaranteed to show a headshot or a placeholder — never an album cover masquerading as the artist. (#92, #94, #96)
+
+**Opt-in artwork on tap.** A new opt-in fetcher (off by default) backfills missing album art from MusicBrainz + Cover Art Archive. Albums view also picks up artwork files dropped manually into `<Drive>/HarmonIQ/Artwork/` — silent reconciliation pass on drive-load. (#74, #79)
+
+**Maintenance, consolidated.** All per-drive library actions live behind one **Refresh…** sheet in Settings: Quick refresh / Reindex tracks / Fetch from internet / Advanced → Rebuild. New `tools/library-doctor.swift` (`--report` / `--dedupe` / `--rebuild`) for offline cleanup; compilation albums fold to one "Various Artists" entry. (#90, #100)
+
+**Lock-screen lockstep.** The lock-screen `MPNowPlayingInfo` widget and the HarmonIQ Live Activity now share a single fan-out path — pause/skip/artwork updates land on both, in the same frame. (#104)
+
+**Visualizer + EQ polish.** Radial Pulse renders unambiguously radial at any energy level. Visualizer style picker commits on first tap. EQ preset picker is easier to tap and faster to commit. (#80, #85, #87)
+
+**AI Smart Play, gracefully absent.** On iPhones without Apple Intelligence and without an Anthropic key configured, the AI section now hides cleanly instead of teasing disabled rows. Cloud fallback continues to work on older devices when a key is configured. (#102)
+
 ### v1.0 — 2026-05-02
 
 The "your collection deserves a real player" release. Brings the offline-first, drive-portable foundation up to a 1.0 feature set built around **data sovereignty** for collectors with thousands of MP3s and ripped CDs.

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,9 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>HarmonIQ — Music for your own collections, ported to your iPhone</title>
-  <meta name="description" content="An iPhone music player built for collectors. Plays the MP3s and ripped CDs you already own, straight off your drive — no streaming, no algorithm, no account. AI curation runs on-device. Open source.">
+  <meta name="description" content="An iPhone music player built for collectors. Plays the MP3s and ripped CDs you already own, straight off your drive — no streaming, no algorithm, no account. v1.1 lands a Charcoal Phosphor palette, browse-by-language, artist headshots, and opt-in album-art fetch.">
   <meta property="og:title" content="HarmonIQ — Music for your own collections">
-  <meta property="og:description" content="Bring your old MP3 folders and ripped-CD archives to a modern iPhone player. Drive-portable library, on-device AI playlists, real 10-band EQ. Works offline.">
+  <meta property="og:description" content="Bring your old MP3 folders and ripped-CD archives to a modern iPhone player. Charcoal Phosphor palette, browse by language, artist headshots, drive-portable library, on-device AI playlists, real 10-band EQ. Works offline.">
   <meta property="og:type" content="website">
   <link rel="stylesheet" href="style.css">
 </head>
@@ -79,8 +79,26 @@
     </div>
   </section>
 
-  <!-- SKIN SHOWCASE -->
+  <!-- WHAT'S NEW (v1.1) -->
   <section class="band">
+    <div class="container">
+      <p class="kicker">// new in v1.1</p>
+      <h2>Charcoal chassis. Heavier knobs. Photos of the artists.</h2>
+      <p class="lede">v1.1 is polish across the palette, the browse modes, and the maintenance flows — without giving up the offline-first stance. The CRT got deeper. The chassis got darker. The artists got faces.</p>
+      <ul class="pillars">
+        <li><span class="ico">🎨</span><h3>Charcoal Phosphor</h3><p>Authentically Winamp-2.x. Graphite chassis, deeper green LCD, amber + red accents in the spectrum bars. Heavier, more machined.</p></li>
+        <li><span class="ico">🌐</span><h3>Browse by language</h3><p>Library → Language partitions your collection into Chinese / English / Others. Heuristic CJK + Latin split — useful when your library sprawls across scripts.</p></li>
+        <li><span class="ico">👤</span><h3>Artist headshots</h3><p>Artists tab is now a visual grid. Opt-in fetcher pulls real headshots from MusicBrainz → Wikidata → Wikimedia → TheAudioDB → Wikipedia. Off by default.</p></li>
+        <li><span class="ico">🖼️</span><h3>Album art on tap</h3><p>Opt-in fetcher backfills missing covers from MusicBrainz + Cover Art Archive. Drop your own files into <code>HarmonIQ/Artwork/</code> on the drive — they get picked up silently.</p></li>
+        <li><span class="ico">🔒</span><h3>Lock screen, in lockstep</h3><p>The lock-screen widget and the Live Activity / Dynamic Island now share a single fan-out path. Pause, skip, artwork — all land on both in the same frame.</p></li>
+        <li><span class="ico">🛠️</span><h3>Maintenance, consolidated</h3><p>One per-drive Refresh sheet: quick refresh, reindex, fetch art, rebuild. Compilation albums fold to "Various Artists". New offline <code>library-doctor</code> CLI.</p></li>
+      </ul>
+      <p class="muted">Plus radial-pulse renders unambiguously radial, the visualizer + EQ pickers commit on first tap, and the AI Smart Play UI hides cleanly when no curator is reachable. Full notes in the <a href="https://github.com/LeoHChen/HarmonIQ/blob/main/README.md#v11--2026-05-03">README changelog</a>.</p>
+    </div>
+  </section>
+
+  <!-- SKIN SHOWCASE -->
+  <section class="band alt">
     <div class="container">
       <p class="kicker">// skins</p>
       <h2>Nine bundled. Bring your own .wsz.</h2>
@@ -100,7 +118,7 @@
   </section>
 
   <!-- VISUALIZERS -->
-  <section class="band alt">
+  <section class="band">
     <div class="container">
       <p class="kicker">// visualizers</p>
       <h2>Sixteen styles, one engine.</h2>
@@ -116,7 +134,7 @@
   </section>
 
   <!-- MAKE IT YOURS -->
-  <section class="band">
+  <section class="band alt">
     <div class="container">
       <p class="kicker">// make it yours</p>
       <h2>The architecture is documented. The patches are welcome.</h2>
@@ -140,7 +158,7 @@
   </section>
 
   <!-- GET IT -->
-  <section class="band alt">
+  <section class="band">
     <div class="container center">
       <p class="kicker">// get it</p>
       <h2>Bring your collection forward.</h2>

--- a/project.yml
+++ b/project.yml
@@ -42,8 +42,8 @@ targets:
       path: HarmonIQ/Info.plist
       properties:
         CFBundleDisplayName: HarmonIQ
-        CFBundleShortVersionString: "1.0"
-        CFBundleVersion: "4"
+        CFBundleShortVersionString: "1.1"
+        CFBundleVersion: "5"
         UILaunchScreen:
           UIImageName: LaunchImage
           UIImageRespectsSafeAreaInsets: false
@@ -115,8 +115,8 @@ targets:
       path: HarmonIQLiveActivity/Info.plist
       properties:
         CFBundleDisplayName: HarmonIQ Live Activity
-        CFBundleShortVersionString: "1.0"
-        CFBundleVersion: "4"
+        CFBundleShortVersionString: "1.1"
+        CFBundleVersion: "5"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.widgetkit-extension
     settings:


### PR DESCRIPTION
## Summary

Cuts the v1.1 / build 5 release.

- Bumps `MARKETING_VERSION` to `1.1` and `CURRENT_PROJECT_VERSION` to `5` in `project.yml`; regenerates `HarmonIQ/Info.plist` + `HarmonIQLiveActivity/Info.plist` via `xcodegen`.
- Adds a v1.1 entry to the README's Releases section.
- Adds a "What's new in v1.1" band to the public landing site (`docs/index.html`) and refreshes the `<meta name="description">` / `og:description` to surface the Charcoal Phosphor palette, browse-by-language, artist headshots, opt-in album art, lock-screen lockstep, and the consolidated per-drive Refresh sheet.

## v1.1 highlights

- **#76** Charcoal Phosphor palette (more authentically Winamp 2.x).
- **#91** Browse library by language (Chinese / English / Others).
- **#92 / #94 / #96** Artists browse → visual grid + opt-in network artist photos with extended fallback chain.
- **#74 / #79** Opt-in MusicBrainz + Cover Art Archive album-art fetcher; Albums view picks up files dropped manually into `<Drive>/HarmonIQ/Artwork/`.
- **#90 / #100** Per-drive maintenance consolidated into one Refresh sheet; compilation albums fold to "Various Artists"; new offline `library-doctor` CLI.
- **#104** Lock-screen `MPNowPlayingInfo` widget and Live Activity now share a single fan-out path.
- **#80 / #85 / #87** Visualizer + EQ pickers commit on first tap; Radial Pulse renders unambiguously radial.
- **#102** AI Smart Play UI hides cleanly without an Apple Intelligence backend or Anthropic key.

## Smoke gate (TESTING.md Section A — iPhone 17 simulator)

- [x] `xcodegen generate` is idempotent (no diff after re-run).
- [x] `xcodebuild build -scheme HarmonIQ -destination 'platform=iOS Simulator,name=iPhone 17' -configuration Debug` is green.
- [x] App cold-launches to the Library tab without crashing; Charcoal Phosphor palette renders as designed.
- [x] `git status` is clean apart from the intentional release deltas.
- [x] Built bundle reports `CFBundleShortVersionString=1.1`, `CFBundleVersion=5`. `Embed build metadata` postBuildScript writes `GitCommit`, `GitTag`, `BuildTimestamp` on a clean build.

## Test plan

- [x] Section A (build + launch) on iPhone 17 simulator.
- [ ] Reviewer: spot-check Releases / Changelog block in the README renders correctly on GitHub.
- [ ] Reviewer: confirm `docs/index.html` "What's new in v1.1" band reads cleanly on https://www.leochen.net/HarmonIQ/ once Pages republishes.