### PR TITLE
Track ExportOptions.plist

### DIFF
--- a/ExportOptions.plist
+++ b/ExportOptions.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>app-store</string>
+    <key>teamID</key>
+    <string>79DDZ6D8WT</string>
+    <key>signingStyle</key>
+    <string>automatic</string>
+    <key>uploadSymbols</key>
+    <true/>
+    <key>destination</key>
+    <string>export</string>
+    <key>stripSwiftSymbols</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Track \`ExportOptions.plist\` so future release agents don't have to recreate it from scratch each release
- Used by \`xcodebuild -exportArchive\` during the v1.1 IPA export and is referenced in \`.claude/agents/release.md\` as the canonical export config
- Team ID \`79DDZ6D8WT\` is already embedded in every signed binary; not a secret

## Test plan
- [x] v1.1 IPA already exported and uploaded to App Store Connect using this file
- [ ] Next release agent run uses the tracked file instead of regenerating

🤖 Generated with [Claude Code](https://claude.com/claude-code)