### PR TITLE
Add public TestFlight link to README + landing site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # HarmonIQ
 
 **Website:** [www.leochen.net/HarmonIQ](https://www.leochen.net/HarmonIQ/) — landing site lives in [`docs/`](docs/).
+**TestFlight:** [Join the public beta](https://testflight.apple.com/join/y4Nmt7V1) (iOS 16+).
 
 > **Music for your own collections, ported to your iPhone.**
 
@@ -95,7 +96,7 @@ project.yml                  # XcodeGen source
 
 ## Releases
 
-See [GitHub Releases](https://github.com/LeoHChen/HarmonIQ/releases) for the full notes and tag history.
+See [GitHub Releases](https://github.com/LeoHChen/HarmonIQ/releases) for the full notes and tag history. The latest build is on TestFlight at [testflight.apple.com/join/y4Nmt7V1](https://testflight.apple.com/join/y4Nmt7V1).
 
 ### v1.1 — 2026-05-03
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -25,7 +25,7 @@
     <h1 class="lcd">HARMONIQ</h1>
     <p class="tagline">Music for your own collections,<br>ported to your iPhone.</p>
     <div class="cta">
-      <a class="btn primary" href="https://github.com/LeoHChen/HarmonIQ#testflight">TestFlight</a>
+      <a class="btn primary" href="https://testflight.apple.com/join/y4Nmt7V1">Join TestFlight</a>
       <a class="btn" href="https://github.com/LeoHChen/HarmonIQ">GitHub</a>
     </div>
   </section>
@@ -163,7 +163,7 @@
     <div class="container center">
       <p class="kicker">// get it</p>
       <h2>Bring your collection forward.</h2>
-      <p class="lede">Twenty years of accumulated MP3s and ripped CDs deserve a player that respects them. HarmonIQ runs on iOS 16+. Source on GitHub; TestFlight invites in the README.</p>
+      <p class="lede">Twenty years of accumulated MP3s and ripped CDs deserve a player that respects them. HarmonIQ runs on iOS 16+. <a href="https://testflight.apple.com/join/y4Nmt7V1">Join the TestFlight</a> · <a href="https://github.com/LeoHChen/HarmonIQ">source on GitHub</a>.</p>
       <div class="cta">
         <a class="btn primary" href="https://github.com/LeoHChen/HarmonIQ">Source on GitHub</a>
         <a class="btn" href="https://github.com/LeoHChen/HarmonIQ/issues/new?labels=enhancement">Request a feature</a>


### PR DESCRIPTION
## Summary
- Hero "TestFlight" button on \`docs/index.html\` now links to the public TestFlight URL (was previously a dead \`#testflight\` anchor on the GitHub repo)
- Footer line on the landing site replaces "TestFlight invites in the README" with direct links
- README masthead surfaces the TestFlight link prominently
- README Releases section also references it for users who land there first

Public link: https://testflight.apple.com/join/y4Nmt7V1

## Test plan
- [ ] \`docs/index.html\` hero "Join TestFlight" button opens the TestFlight invitation page
- [ ] README displays the TestFlight link near the top
- [ ] Both files render correctly on GitHub Pages after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)