### PR TITLE
chore: flesh out coder.md with Rules sections

### DIFF
--- a/.claude/agents/coder.md
+++ b/.claude/agents/coder.md
@@ -87,7 +87,63 @@ There's no test target. The static check is the build; functional verification i
 7. Open a draft PR using `gh pr create --draft` with the smoke-test checklist filled in for the sections you ran.
 
 ## Rules
+## 1. Think Before Coding
 
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+## 5. Eng Process
 - Don't commit unless the user asked you to. When you do, never use `--no-verify`.
 - Don't push to a branch that's already in review without flagging it.
 - If you discover the task needs scope it doesn't have (a missing API, a different bug, a design decision), stop and surface the question rather than expanding silently.


### PR DESCRIPTION
## Summary
Cherry-picks a 56-line addition to `.claude/agents/coder.md` that was stranded on the merged `chore/testflight-link` branch.

Adds five Rules subsections to the coder agent's instructions:
1. Think Before Coding — assume nothing, surface tradeoffs
2. Simplicity First — minimum code, no speculative abstractions
3. Surgical Changes — touch only what's necessary
4. Goal-Driven Execution — define verifiable success criteria
5. Eng Process (preserves existing rules)

Authored by @LeoHChen 2026-05-09; cherry-picked here onto a fresh branch from main per repo's "new branch for new PR" convention.

## Test plan
- [x] Cherry-pick clean (no conflicts)
- [x] Diff is the same 56 lines added to coder.md
- N/A — agent-instructions change, no build impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)