### PR TITLE
Export VLC-compatible .m3u8 playlists onto the drive

### DIFF
--- a/HarmonIQ.xcodeproj/project.pbxproj
+++ b/HarmonIQ.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		D0B58783C53C00AAF777EA5B /* SkinnedEqualizerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91184AF88772B10074EACE0A /* SkinnedEqualizerView.swift */; };
 		D14CC8746BAA04AFF959DFB5 /* MetadataExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53B7620084258E7F659C7D7 /* MetadataExtractor.swift */; };
 		D2EA2CFCD49E1790A8904149 /* WinampTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A34D43E2D09B36F9A92DF67 /* WinampTheme.swift */; };
+		D9E50AE7D183BBE67686E775 /* M3UPlaylistExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70DB80B15C7353CE910DB21 /* M3UPlaylistExporter.swift */; };
 		DA3451E853523F3F3794A302 /* ArtistsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D6E4A738A357E6A860D0E0 /* ArtistsView.swift */; };
 		DAC622E13BE984A57D2E9C86 /* HarmonIQApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA4029B61958E1D8F6162CCA /* HarmonIQApp.swift */; };
 		DC9F3F437F7B059AD8D253B5 /* DriveLibraryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFB4D3197C2EC465A4B964C /* DriveLibraryStore.swift */; };
@@ -147,6 +148,7 @@
 		C20AD805166CAC672F2833BC /* HarmonIQ.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = HarmonIQ.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C4D685B9A89C2B6EDCCCB4AB /* AlbumsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumsView.swift; sourceTree = "<group>"; };
 		C6203F24B0D3D962883456DA /* SpriteButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpriteButton.swift; sourceTree = "<group>"; };
+		C70DB80B15C7353CE910DB21 /* M3UPlaylistExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = M3UPlaylistExporter.swift; sourceTree = "<group>"; };
 		C9A3E5FF59C499E1F16218AA /* SmartPlayAI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartPlayAI.swift; sourceTree = "<group>"; };
 		CB2650366DAD3EEB077B33CD /* LiveActivityController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityController.swift; sourceTree = "<group>"; };
 		CC4F2B572BEA8AA004255D82 /* HarmonIQActivityAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarmonIQActivityAttributes.swift; sourceTree = "<group>"; };
@@ -328,6 +330,7 @@
 				9BA0C5DAF97A47E057019501 /* BookmarkStore.swift */,
 				BEFB4D3197C2EC465A4B964C /* DriveLibraryStore.swift */,
 				9F130079612D4D04F3BDAF75 /* LibraryStore.swift */,
+				C70DB80B15C7353CE910DB21 /* M3UPlaylistExporter.swift */,
 				F220F64AA1D95133ED5A5159 /* SandboxRootStore.swift */,
 			);
 			path = Persistence;
@@ -513,6 +516,7 @@
 				A10BD1CC54DC77E7DF551BA6 /* LibraryView.swift in Sources */,
 				116A7F3DD4FF063CD5776F50 /* LiveActivityController.swift in Sources */,
 				C47BFF9A3192AFF82CDC5440 /* LlamaSilhouette.swift in Sources */,
+				D9E50AE7D183BBE67686E775 /* M3UPlaylistExporter.swift in Sources */,
 				D14CC8746BAA04AFF959DFB5 /* MetadataExtractor.swift in Sources */,
 				3EE13B1011444446AF4C9346 /* MusicIndexer.swift in Sources */,
 				409179BD52B576D6D435FD06 /* NowPlayingManager.swift in Sources */,

--- a/HarmonIQ/Persistence/LibraryStore.swift
+++ b/HarmonIQ/Persistence/LibraryStore.swift
@@ -383,8 +383,20 @@ final class LibraryStore: ObservableObject {
             try? SandboxRootStore.writePlaylists(file, rootID: root.id)
             return
         }
+        // Resolve each owned playlist's track IDs to tracks (in playlist order) so
+        // we can also emit VLC-compatible .m3u8 sidecars onto the drive. IDs that
+        // don't resolve — e.g. another drive's tracks, or rows missing in memory —
+        // are dropped; the line is only written when we know the on-drive path.
+        let byID: [String: Track] = Dictionary(
+            tracks.filter { $0.rootBookmarkID == rootID }.map { ($0.stableID, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let resolved: [(name: String, tracks: [Track])] = owned.map { playlist in
+            (name: playlist.name, tracks: playlist.trackIDs.compactMap { byID[$0] })
+        }
         withDriveAccess(root) { driveURL in
             try DriveLibraryStore.writePlaylists(file, driveRoot: driveURL)
+            try M3UPlaylistExporter.export(resolved, driveRoot: driveURL)
         }
     }
 

--- a/HarmonIQ/Persistence/M3UPlaylistExporter.swift
+++ b/HarmonIQ/Persistence/M3UPlaylistExporter.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// Exports HarmonIQ playlists as standard `.m3u8` files onto the drive so they can
+/// be opened in VLC — or any desktop player — when the drive is mounted on a Mac/PC.
+///
+/// HarmonIQ's own `playlists.json` is keyed by `Track.stableID` (a path hash) and is
+/// not understood by other players. This sidecar writes the same playlists in the
+/// universally-recognised Extended M3U format. Layout on the drive:
+///
+///   <DriveRoot>/HarmonIQ/Playlists/<name>.m3u8
+///
+/// Entry paths are written **relative to that folder** (`../../<relativePath>`), so
+/// they resolve regardless of where the OS mounts the drive (`/Volumes/MyHD` on a
+/// Mac, a drive letter on Windows, the security-scoped URL on iOS). `.m3u8` (UTF-8)
+/// is used rather than `.m3u` so non-ASCII artist/track paths survive intact.
+///
+/// The whole folder is regenerated on every write: the `.m3u8` files we manage are
+/// cleared first, so renamed or deleted playlists never leave orphans behind.
+enum M3UPlaylistExporter {
+    static let playlistsFolderName = "Playlists"
+
+    static func playlistsFolder(in driveRoot: URL) -> URL {
+        DriveLibraryStore.harmonIQFolder(in: driveRoot)
+            .appendingPathComponent(playlistsFolderName, isDirectory: true)
+    }
+
+    /// Regenerates the `Playlists/` folder from `playlists`. Each entry pairs a
+    /// playlist name with its tracks already resolved **in playlist order** — the
+    /// caller drops track IDs that don't resolve (e.g. an offline drive), so a line
+    /// is only emitted for a track whose on-drive path is known.
+    static func export(_ playlists: [(name: String, tracks: [Track])], driveRoot: URL) throws {
+        let fm = FileManager.default
+        let folder = playlistsFolder(in: driveRoot)
+
+        // Wipe the .m3u8 files we manage so renames/deletes don't leave orphans.
+        // Anything else the user dropped in the folder is left untouched.
+        if let existing = try? fm.contentsOfDirectory(at: folder, includingPropertiesForKeys: nil) {
+            for url in existing where url.pathExtension.lowercased() == "m3u8" {
+                try? fm.removeItem(at: url)
+            }
+        }
+
+        guard !playlists.isEmpty else { return }
+        try fm.createDirectory(at: folder, withIntermediateDirectories: true)
+
+        // De-collide filenames: two playlists may share a (sanitised) name.
+        var usedNames = Set<String>()
+        for playlist in playlists {
+            let base = sanitizedFilename(playlist.name)
+            var name = base
+            var suffix = 2
+            while !usedNames.insert(name.lowercased()).inserted {
+                name = "\(base) (\(suffix))"
+                suffix += 1
+            }
+            let url = folder.appendingPathComponent(name).appendingPathExtension("m3u8")
+            let data = Data(m3u8Content(for: playlist.tracks).utf8)
+            try data.write(to: url, options: .atomic)
+        }
+    }
+
+    /// Builds Extended M3U text for an ordered track list. Relative entries point
+    /// up two levels — out of `HarmonIQ/Playlists/` to the drive root — then down
+    /// each track's `relativePath`.
+    static func m3u8Content(for tracks: [Track]) -> String {
+        var lines = ["#EXTM3U"]
+        for track in tracks {
+            let seconds = Int(track.duration.rounded())
+            lines.append("#EXTINF:\(seconds),\(track.displayArtist) - \(track.displayTitle)")
+            lines.append((["..", ".."] + track.relativePath).joined(separator: "/"))
+        }
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    /// Strips characters that are illegal in filenames on common filesystems
+    /// (FAT/exFAT/HFS+/APFS/NTFS) so the export works on whatever the drive is
+    /// formatted as. Falls back to "Playlist" if nothing usable remains.
+    static func sanitizedFilename(_ name: String) -> String {
+        let illegal = CharacterSet(charactersIn: "/\\:*?\"<>|")
+        let cleaned = name
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .unicodeScalars
+            .reduce(into: "") { result, scalar in
+                result.unicodeScalars.append(illegal.contains(scalar) ? "_" : scalar)
+            }
+        return cleaned.isEmpty ? "Playlist" : cleaned
+    }
+}


### PR DESCRIPTION
## What

Adds a feature: HarmonIQ now writes standard **Extended M3U (`.m3u8`)** playlist files onto the drive alongside the existing `playlists.json`, so playlists can be opened in **VLC** (or any desktop player) when the HD is mounted on a Mac/PC.

### Why
`playlists.json` is keyed by `Track.stableID` (a path hash) — only HarmonIQ understands it. Plugging the drive into a MacBook gave you the audio files but no openable playlists. This exports a portable sidecar in a universal format.

### How
- **New `M3UPlaylistExporter`** writes `<DriveRoot>/HarmonIQ/Playlists/<name>.m3u8`.
  - Entry paths are **relative** (`../../<relativePath>`) so they resolve regardless of where the OS mounts the drive (`/Volumes/MyHD`, a Windows drive letter, the iOS security-scoped URL).
  - `.m3u8` (UTF-8) preserves non-ASCII artist/track paths.
  - `#EXTINF` carries duration (rounded seconds) + `Artist - Title`.
  - Filenames sanitized for FAT/exFAT/HFS+/APFS/NTFS; name collisions de-duped (`Name (2)`).
  - The folder is **regenerated on every write**, so renamed/deleted playlists leave no orphans; non-`.m3u8` files in the folder are left untouched.
- **Hooked into `LibraryStore.writePlaylistsToDrive`** — the single choke point every playlist mutation passes through. Track IDs are resolved to tracks in playlist order; unresolved/offline IDs are dropped. Read-only roots (sandbox, not external HDs) are skipped.

### Where to find them
On the mounted drive: `HarmonIQ/Playlists/*.m3u8` — double-click to open in VLC.

## Testing
- [x] **Section A** — Xcode build succeeds (`xcodebuild` + XcodeBuildMCP, zero errors/warnings); app installs, launches, and renders Library in the iPhone 17 simulator with no regression.
- [x] M3U8 generation logic validated with standalone assertions: `#EXTM3U` header, `#EXTINF` rounded duration + display title, `../../` relative paths, UTF-8 (e.g. `坂本龍一`) preserved, filename sanitization + blank fallback.
- [ ] Playlist-mutation paths (create/rename/delete/add-track/Favorites) on a real read-write drive — manual pass recommended on device with an external HD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)