### PR TITLE
VLC export: run on load/reindex + add whole-drive "All Tracks" playlist

### DIFF
--- a/HarmonIQ/Persistence/LibraryStore.swift
+++ b/HarmonIQ/Persistence/LibraryStore.swift
@@ -396,17 +396,30 @@ final class LibraryStore: ObservableObject {
     }
 
     /// Resolves every playlist owned by `rootID` to `(name, orderedTracks)` for the
-    /// VLC `.m3u8` export. Track IDs that don't resolve — another drive's tracks, or
-    /// rows missing from memory (e.g. drive offline) — are dropped, so a line is only
-    /// emitted when we know the on-drive path.
+    /// VLC `.m3u8` export, plus a synthetic "All Tracks" entry containing the drive's
+    /// entire library so the whole drive opens in VLC with one file. Track IDs that
+    /// don't resolve — another drive's tracks, or rows missing from memory (e.g.
+    /// drive offline) — are dropped, so a line is only emitted when we know the
+    /// on-drive path.
     private func resolvedPlaylists(forRoot rootID: UUID) -> [(name: String, tracks: [Track])] {
+        // `tracks` is already kept in a stable display order by mergeTracks, so the
+        // "All Tracks" list mirrors how the library reads in the app.
+        let driveTracks = tracks.filter { $0.rootBookmarkID == rootID }
         let byID: [String: Track] = Dictionary(
-            tracks.filter { $0.rootBookmarkID == rootID }.map { ($0.stableID, $0) },
+            driveTracks.map { ($0.stableID, $0) },
             uniquingKeysWith: { first, _ in first }
         )
-        return playlists
+        var result: [(name: String, tracks: [Track])] = []
+        // Drive-named so it doesn't collide with a user playlist literally called
+        // "All Tracks". Listed first so it reliably keeps its clean filename.
+        if !driveTracks.isEmpty {
+            let driveName = roots.first(where: { $0.id == rootID })?.displayName ?? "Drive"
+            result.append((name: "All Tracks (\(driveName))", tracks: driveTracks))
+        }
+        result.append(contentsOf: playlists
             .filter { $0.rootBookmarkID == rootID }
-            .map { playlist in (name: playlist.name, tracks: playlist.trackIDs.compactMap { byID[$0] }) }
+            .map { playlist in (name: playlist.name, tracks: playlist.trackIDs.compactMap { byID[$0] }) })
+        return result
     }
 
     /// (Re)writes only the VLC-compatible `.m3u8` sidecars for `rootID` — no

--- a/HarmonIQ/Persistence/LibraryStore.swift
+++ b/HarmonIQ/Persistence/LibraryStore.swift
@@ -162,6 +162,11 @@ final class LibraryStore: ObservableObject {
             mergePlaylists(forRoot: root.id, with: mapped)
         }
 
+        // Regenerate the VLC .m3u8 sidecars from whatever we just loaded. This is
+        // what makes playlists created before the export feature shipped (or by
+        // another device) appear on the drive without the user editing them.
+        exportVLCPlaylists(forRoot: root.id)
+
         // Adopt any artwork files that landed on disk between launches but
         // aren't referenced in library.json yet (issue #77). This is a
         // cheap pass: scan the Artwork folder, match by sha1 filename,
@@ -383,19 +388,37 @@ final class LibraryStore: ObservableObject {
             try? SandboxRootStore.writePlaylists(file, rootID: root.id)
             return
         }
-        // Resolve each owned playlist's track IDs to tracks (in playlist order) so
-        // we can also emit VLC-compatible .m3u8 sidecars onto the drive. IDs that
-        // don't resolve — e.g. another drive's tracks, or rows missing in memory —
-        // are dropped; the line is only written when we know the on-drive path.
+        let resolved = resolvedPlaylists(forRoot: rootID)
+        withDriveAccess(root) { driveURL in
+            try DriveLibraryStore.writePlaylists(file, driveRoot: driveURL)
+            try M3UPlaylistExporter.export(resolved, driveRoot: driveURL)
+        }
+    }
+
+    /// Resolves every playlist owned by `rootID` to `(name, orderedTracks)` for the
+    /// VLC `.m3u8` export. Track IDs that don't resolve — another drive's tracks, or
+    /// rows missing from memory (e.g. drive offline) — are dropped, so a line is only
+    /// emitted when we know the on-drive path.
+    private func resolvedPlaylists(forRoot rootID: UUID) -> [(name: String, tracks: [Track])] {
         let byID: [String: Track] = Dictionary(
             tracks.filter { $0.rootBookmarkID == rootID }.map { ($0.stableID, $0) },
             uniquingKeysWith: { first, _ in first }
         )
-        let resolved: [(name: String, tracks: [Track])] = owned.map { playlist in
-            (name: playlist.name, tracks: playlist.trackIDs.compactMap { byID[$0] })
-        }
+        return playlists
+            .filter { $0.rootBookmarkID == rootID }
+            .map { playlist in (name: playlist.name, tracks: playlist.trackIDs.compactMap { byID[$0] }) }
+    }
+
+    /// (Re)writes only the VLC-compatible `.m3u8` sidecars for `rootID` — no
+    /// `playlists.json` rewrite. Called on drive load and after a reindex so the
+    /// sidecars exist (and stay path-fresh) for playlists that haven't been edited
+    /// since the feature shipped. The exporter regenerates the whole `Playlists/`
+    /// folder, so this is idempotent and self-healing. No-op for read-only roots
+    /// (the drive can't be written) and when the drive is offline.
+    func exportVLCPlaylists(forRoot rootID: UUID) {
+        guard let root = roots.first(where: { $0.id == rootID }), !root.isReadOnly else { return }
+        let resolved = resolvedPlaylists(forRoot: rootID)
         withDriveAccess(root) { driveURL in
-            try DriveLibraryStore.writePlaylists(file, driveRoot: driveURL)
             try M3UPlaylistExporter.export(resolved, driveRoot: driveURL)
         }
     }
@@ -484,6 +507,9 @@ final class LibraryStore: ObservableObject {
         withDriveAccess(root) { driveURL in
             try DriveLibraryStore.writeLibrary(file, driveRoot: driveURL)
         }
+        // A reindex can change track paths (moved/renamed files). Refresh the VLC
+        // .m3u8 sidecars so their relative entries point at the new locations.
+        exportVLCPlaylists(forRoot: rootID)
     }
 
     private func mergeTracks(forRoot rootID: UUID, with newTracks: [Track]) {


### PR DESCRIPTION
Two related follow-ups to the VLC `.m3u8` export (#134).

## 1. Export on drive load + reindex (not just on edits)

**Problem:** No `.m3u8` appeared after a **reindex**, and playlists made **before** the feature shipped (or on another device) never got sidecars — because the export was only called from `writePlaylistsToDrive`, which runs on playlist *mutations* (create/rename/delete/add-track/Favorites). Reindex (`replaceTracks`) and load (`loadDriveData`) never touched it.

**Fix:**
- New `exportVLCPlaylists(forRoot:)` writes only the `.m3u8` files; track-resolution factored into `resolvedPlaylists(forRoot:)`, shared with `writePlaylistsToDrive`.
- Called from `loadDriveData` (every launch/reconnect) and `replaceTracks` (after reindex, so entries follow moved/renamed files).
- Idempotent + self-healing (the exporter regenerates the whole `Playlists/` folder). No-op for read-only/offline drives.

## 2. Whole-drive "All Tracks" playlist

Adds a synthetic **`All Tracks (<DriveName>)`** `.m3u8` containing the drive's entire library, so the whole drive opens in VLC with one file — alongside the per-playlist sidecars. Built from the drive's in-memory tracks (already in display order), listed first and drive-named so it keeps a clean filename and won't collide with a user playlist called "All Tracks". Skipped when the drive has no tracks.

## Result on the drive
`HarmonIQ/Playlists/`:
- `All Tracks (<DriveName>).m3u8` — everything on the drive
- `<each playlist>.m3u8`

## Testing
- [x] **Section A** — `build_run_sim` SUCCEEDED (zero errors/warnings); app launches and renders Library in the iPhone 17 simulator.
- [ ] On-device with an external HD: after just launching / reindexing (no edit), confirm `HarmonIQ/Playlists/` contains the `All Tracks (...)` file + one per playlist, and all open in VLC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)