### PR TITLE
release: v1.1.1 (build 7)

### DIFF
--- a/HarmonIQ/Info.plist
+++ b/HarmonIQ/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1</string>
+	<string>1.1.1</string>
 	<key>CFBundleVersion</key>
-	<string>6</string>
+	<string>7</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSSupportsOpeningDocumentsInPlace</key>

--- a/HarmonIQLiveActivity/Info.plist
+++ b/HarmonIQLiveActivity/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1</string>
+	<string>1.1.1</string>
 	<key>CFBundleVersion</key>
-	<string>6</string>
+	<string>7</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/README.md
+++ b/README.md
@@ -98,6 +98,16 @@ project.yml                  # XcodeGen source
 
 See [GitHub Releases](https://github.com/LeoHChen/HarmonIQ/releases) for the full notes and tag history. The latest build is on TestFlight at [testflight.apple.com/join/y4Nmt7V1](https://testflight.apple.com/join/y4Nmt7V1).
 
+### v1.1.1 — 2026-06-07
+
+The "take your playlists with you" release. HarmonIQ now writes standard VLC-compatible playlists onto the drive, so the same library plays on the desktop without re-exporting anything.
+
+#### v1.1.1 build 7 — 2026-06-07
+
+- **VLC-compatible playlist export.** Every playlist is mirrored to the drive as a standard Extended M3U file at `<Drive>/HarmonIQ/Playlists/<name>.m3u8`, with relative paths that resolve wherever the drive is mounted (Mac/PC). Plug the drive into a computer and open them straight in VLC. (#134, #135)
+- **Whole-drive "All Tracks" playlist.** A `All Tracks (<DriveName>).m3u8` containing the entire drive library is exported alongside the per-playlist files, so the whole collection opens in one click. (#135)
+- **Automatic + self-healing.** Sidecars are (re)generated on every playlist edit, drive load, and reindex — so playlists made before this release, or on another device, appear without any manual step, and entries follow files that move between scans. (#135)
+
 ### v1.1 — 2026-05-03
 
 The "make it look right, find it fast, keep it offline" release. Polish across the palette, the browse modes, the maintenance flows, and the lock-screen — without giving up the offline-first stance.

--- a/project.yml
+++ b/project.yml
@@ -42,8 +42,8 @@ targets:
       path: HarmonIQ/Info.plist
       properties:
         CFBundleDisplayName: HarmonIQ
-        CFBundleShortVersionString: "1.1"
-        CFBundleVersion: "6"
+        CFBundleShortVersionString: "1.1.1"
+        CFBundleVersion: "7"
         ITSAppUsesNonExemptEncryption: false
         UILaunchScreen:
           UIImageName: LaunchImage
@@ -116,8 +116,8 @@ targets:
       path: HarmonIQLiveActivity/Info.plist
       properties:
         CFBundleDisplayName: HarmonIQ Live Activity
-        CFBundleShortVersionString: "1.1"
-        CFBundleVersion: "6"
+        CFBundleShortVersionString: "1.1.1"
+        CFBundleVersion: "7"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.widgetkit-extension
     settings:


### PR DESCRIPTION
Version + build bump for the VLC playlist export feature (#134, #135).

- `project.yml`: `CFBundleShortVersionString` 1.1 → **1.1.1**, `CFBundleVersion` 6 → **7** (app + Live Activity targets); project regenerated via XcodeGen.
- README: new **v1.1.1 — 2026-06-07** changelog entry.

Verified the built app reports `1.1.1 (7)` (`Info.plist`); `build_run_sim` SUCCEEDED with zero errors/warnings.

After merge: tag `v1.1.1`, create the GitHub release, then archive + upload to TestFlight/App Store Connect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)